### PR TITLE
Include release directory in the npm package.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,5 @@
+typings
+.idea
+.clang-format
+.travis.yml
+tsd.json

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -19,7 +19,7 @@ var TSC_OPTIONS = {
   // (the alternative is to include node_modules paths
   // in the src arrays below for compilation)
   noExternalResolve: false,
-  definitionFiles: true,
+  declarationFiles: true,
   noEmitOnError: true,
 };
 var tsProject = ts.createProject(TSC_OPTIONS);
@@ -47,7 +47,8 @@ gulp.task('compile', function() {
                      .on('error', onCompileError);
   return merge([
     tsResult.dts.pipe(gulp.dest('release/definitions')),
-    tsResult.js.pipe(sourcemaps.write()),
+    // Write external sourcemap next to the js file
+    tsResult.js.pipe(sourcemaps.write('.')).pipe(gulp.dest('release/js')),
     tsResult.js.pipe(gulp.dest('release/js')),
   ]);
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts2dart",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Transpile TypeScript code to Dart",
   "main": "release/js/main.js",
   "directories": {


### PR DESCRIPTION
I learned from https://docs.npmjs.com/misc/developers that npm will use the .gitignore file by default, so it was
ignoring the compiled code. It needs to be instructed to instead ignore the uncompiled code.
