### PR TITLE
Only transpile if the script is the entry point.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -42,7 +42,7 @@ var onCompileError = function(err) {
 
 gulp.task('compile', function() {
   hasCompileError = false;
-  var tsResult = gulp.src(['*.ts', 'typings/**/*'])
+  var tsResult = gulp.src(['*.ts', 'typings/**/*.d.ts'])
                      .pipe(sourcemaps.init())
                      .pipe(ts(tsProject))
                      .on('error', onCompileError);
@@ -59,7 +59,7 @@ gulp.task('test.compile', ['compile'], function(done) {
     done();
     return;
   }
-  return gulp.src(['test/*.ts', '*.ts', 'typings/**/*'])
+  return gulp.src(['test/*.ts', '*.ts', 'typings/**/*.d.ts'])
       .pipe(sourcemaps.init())
       .pipe(ts(tsProject))
       .on('error', onCompileError)

--- a/main.ts
+++ b/main.ts
@@ -554,4 +554,6 @@ export function translateFiles(fileNames: string[]): void {
 }
 
 // CLI entry point
-translateFiles(process.argv.slice(2));
+if (require.main === module) {
+  translateFiles(process.argv.slice(2));
+}


### PR DESCRIPTION
Also be more selective about which files to pick
up in typings, as our TS compiler now accepts all
file types, not just .ts files.
