### PR TITLE
Silently ignore Type Literals (unsupported by Dart)

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -458,7 +458,6 @@ class Translator {
       case ts.SyntaxKind.ProtectedKeyword:
         // Error - handled in `visitDeclarationModifiers` above.
         break;
-
       case ts.SyntaxKind.PropertyAccessExpression:
         var propAccess = <ts.PropertyAccessExpression>node;
         this.visit(propAccess.expression);
@@ -529,6 +528,11 @@ class Translator {
       case ts.SyntaxKind.Identifier:
         var ident = <ts.Identifier>node;
         this.emit(ident.text);
+        break;
+
+      case ts.SyntaxKind.TypeLiteral:
+        // Dart doesn't support type literals.
+        this.emit('dynamic');
         break;
 
       case ts.SyntaxKind.TypeReference:

--- a/test/DartTest.ts
+++ b/test/DartTest.ts
@@ -29,6 +29,8 @@ describe('transpile to dart', () => {
   describe('types', () => {
     it('supports qualified names',
        () => { expectTranslate('var x: foo.Bar;').to.equal(' foo . Bar x ;'); });
+    it('drops type literals',
+       () => { expectTranslate('var x: {x: string, y: number};').to.equal(' dynamic x ;'); });
   });
 
   describe('variables', () => {


### PR DESCRIPTION
This doesn't fix #65, but works around it.
