### PR TITLE
Ignore type declarations on named parameters.

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -673,9 +673,13 @@ class Translator {
         var paramDecl = <ts.ParameterDeclaration>node;
         if (paramDecl.dotDotDotToken) this.reportError(node, 'rest parameters are unsupported');
         if (paramDecl.initializer) this.emit('[');
-        if (paramDecl.type) this.visit(paramDecl.type);
-        if (paramDecl.type && paramDecl.name.kind === ts.SyntaxKind.ObjectBindingPattern) {
-          this.reportError(paramDecl.type, 'types on named parameters are unsupported');
+        if (paramDecl.type) {
+          if (paramDecl.name.kind !== ts.SyntaxKind.ObjectBindingPattern) {
+            this.visit(paramDecl.type);
+          } else {
+            // TODO(martinprobst): These are currently silently ignored.
+            // this.reportError(paramDecl.type, 'types on named parameters are unsupported');
+          }
         }
         this.visit(paramDecl.name);
         if (paramDecl.initializer) {

--- a/test/DartTest.ts
+++ b/test/DartTest.ts
@@ -173,7 +173,10 @@ describe('transpile to dart', () => {
     it('supports named parameters', () => {
       expectTranslate('function x({a = "x", b}) { return a + b; }')
           .to.equal(' x ( { a : "x" , b } ) { return a + b ; }');
-      chai.expect(() => translateSource('function x({a}: number) { return a + b; }'))
+    });
+    // TODO(martinprobst): Support types on named parameters.
+    it.skip('fails for types on named parameters', () => {
+      expectErroneousCode('function x({a}: number) { return a + b; }')
           .to.throw('types on named parameters are unsupported');
     });
     it('hacks last object literal parameters into named parameter', () => {


### PR DESCRIPTION
This is for compatibility with the Traceur transpilation. Medium term
we might want to understand and map the types.

Fixes #66.
