### PR TITLE
Support "import * as foo" style imports.

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -721,7 +721,6 @@ class Translator {
         this.emit('import');
         this.visitExternalModuleReferenceExpr(importDecl.moduleSpecifier);
         if (importDecl.importClause) {
-          this.emit('show');
           this.visit(importDecl.importClause);
         } else {
           this.reportError(importDecl, 'bare import is unsupported');
@@ -731,10 +730,18 @@ class Translator {
       case ts.SyntaxKind.ImportClause:
         var importClause = <ts.ImportClause>node;
         if (importClause.name) this.visit(importClause.name);
-        if (importClause.namedBindings) this.visit(importClause.namedBindings);
+        if (importClause.namedBindings) {
+          this.visit(importClause.namedBindings);
+        }
+        break;
+      case ts.SyntaxKind.NamespaceImport:
+        var nsImport = <ts.NamespaceImport>node;
+        this.emit('as');
+        this.visit(nsImport.name);
         break;
       case ts.SyntaxKind.NamedImports:
       case ts.SyntaxKind.NamedExports:
+        this.emit('show');
         this.visitList((<ts.NamedImportsOrExports>node).elements);
         break;
       case ts.SyntaxKind.ImportSpecifier:

--- a/test/DartTest.ts
+++ b/test/DartTest.ts
@@ -402,6 +402,9 @@ describe('transpile to dart', () => {
     it('translates import from statements', () => {
       expectTranslate('import {x,y} from "z";').to.equal(' import "package:z.dart" show x , y ;');
     });
+    it('translates import star', () => {
+      expectTranslate('import * as foo from "z";').to.equal(' import "package:z.dart" as foo ;');
+    });
     it('allows import dart file from relative path', () => {
       expectTranslate('import x = require("./y")').to.equal(' import "./y.dart" as x ;');
       expectTranslate('import {x} from "./y"').to.equal(' import "./y.dart" show x ;');
@@ -416,6 +419,8 @@ describe('transpile to dart', () => {
        () => { expectTranslate('export class X {}').to.equal(' class X { }'); });
     it('allows export declarations',
        () => { expectTranslate('export * from "X";').to.equal(' export "X" ;'); });
+    it('allows named export declarations',
+       () => { expectTranslate('export {a, b} from "X";').to.equal(' export "X" show a , b ;'); });
   });
 
   describe('errors', () => {


### PR DESCRIPTION
Fixes #68.
