### PR TITLE
Initial support for decorators.

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "source-map-support": "^0.2.9",
-    "typescript": "mprobst/TypeScript#release"
+    "typescript": "mprobst/TypeScript#decorators_min"
   },
   "devDependencies": {
     "chai": "^2.1.1",

--- a/test/DartTest.ts
+++ b/test/DartTest.ts
@@ -170,6 +170,24 @@ describe('transpile to dart', () => {
     });
   });
 
+  describe('decorators', () => {
+    it('translates plain decorators', () => {
+      expectTranslate('@A class X {}').to.equal(' @ A class X { }');
+    });
+    it('translates arguments', () => {
+      expectTranslate('@A(a, b) class X {}').to.equal(' @ A ( a , b ) class X { }');
+    });
+    it('translates on functions', () => {
+      expectTranslate('@A function f() {}').to.equal(' @ A f ( ) { }');
+    });
+    it('translates on properties', () => {
+      expectTranslate('class X { @A p; }').to.equal(' class X { @ A var p ; }');
+    });
+    it('translates on parameters', () => {
+      expectTranslate('function f (@A p) {}').to.equal(' f ( @ A p ) { }');
+    });
+  });
+
   describe('functions', () => {
     it('supports declarations',
        () => { expectTranslate('function x() {}').to.equal(' x ( ) { }'); });


### PR DESCRIPTION
This is based on a hacked up version of TypeScript including @mhegazy's minimal decorators pull request. I.e. this is to allow further progress on ts2dart transpilation, not a final solution.

So this relates to #72, but doesn't fix it.
