### PR TITLE
Run clang-format on the code.

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -30,7 +30,7 @@ class Translator {
 
   visitEach(nodes: ts.Node[]) { nodes.forEach((n) => this.visit(n)); }
 
-  visitEachIfPresent(nodes?: ts.Node[]) {
+  visitEachIfPresent(nodes ?: ts.Node[]) {
     if (nodes) this.visitEach(nodes);
   }
 
@@ -47,7 +47,7 @@ class Translator {
     this.emit(')');
   }
 
-  visitFunctionLike(fn: ts.FunctionLikeDeclaration, accessor?: string) {
+  visitFunctionLike(fn: ts.FunctionLikeDeclaration, accessor ?: string) {
     if (fn.type) this.visit(fn.type);
     if (accessor) this.emit(accessor);
     if (fn.name) this.visit(fn.name);
@@ -356,18 +356,18 @@ class Translator {
           this.visit(tryStmt.finallyBlock);
         }
         break;
-       case ts.SyntaxKind.CatchClause:
-         var ctch = <ts.CatchClause>node;
-         if (ctch.variableDeclaration.type) {
-           this.emit('on');
-           this.visit(ctch.variableDeclaration.type);
-         }
-         this.emit('catch');
-         this.emit('(');
-         this.visit(ctch.variableDeclaration.name);
-         this.emit(')');
-         this.visit(ctch.block);
-         break;
+      case ts.SyntaxKind.CatchClause:
+        var ctch = <ts.CatchClause>node;
+        if (ctch.variableDeclaration.type) {
+          this.emit('on');
+          this.visit(ctch.variableDeclaration.type);
+        }
+        this.emit('catch');
+        this.emit('(');
+        this.visit(ctch.variableDeclaration.name);
+        this.emit(')');
+        this.visit(ctch.block);
+        break;
 
       // Literals.
       case ts.SyntaxKind.NumericLiteral:
@@ -398,16 +398,15 @@ class Translator {
         this.emit(`'''${(<ts.StringLiteralExpression>node).text}`); //highlighting bug:'
         break;
       case ts.SyntaxKind.TemplateTail:
-        this.result += `${
-        (<ts.StringLiteralExpression>node).text}'''`; //highlighting bug:'
+        this.result += `${(<ts.StringLiteralExpression>node).text}'''`; //highlighting bug:'
         break;
       case ts.SyntaxKind.TemplateSpan:
         var span = <ts.TemplateSpan>node;
         if (span.expression) {
-        // Do not emit extra whitespace inside the string template
-        this.result += '${';
-        this.visit(span.expression);
-        this.result += '}';
+          // Do not emit extra whitespace inside the string template
+          this.result += '${';
+          this.visit(span.expression);
+          this.result += '}';
         }
         if (span.literal) this.visit(span.literal);
         break;

--- a/test/DartTest.ts
+++ b/test/DartTest.ts
@@ -117,8 +117,7 @@ describe('transpile to dart', () => {
             .to.equal(' class X { x ( num a , String b ) { return 42 ; } }');
       });
       it('supports get methods', () => {
-        expectTranslate('class X { get y(): number {} }')
-            .to.equal(' class X { num get y { } }');
+        expectTranslate('class X { get y(): number {} }').to.equal(' class X { num get y { } }');
       });
       it('supports set methods', () => {
         expectTranslate('class X { set y(n: number) {} }')
@@ -165,27 +164,21 @@ describe('transpile to dart', () => {
           .to.equal(' switch ( c ) { case Color . Red : break ; default : break ; }');
     });
     it('does not support const enum', () => {
-      expectErroneousCode('const enum Color { Red }')
-          .to.throw('const enums are not supported');
+      expectErroneousCode('const enum Color { Red }').to.throw('const enums are not supported');
     });
   });
 
   describe('decorators', () => {
-    it('translates plain decorators', () => {
-      expectTranslate('@A class X {}').to.equal(' @ A class X { }');
-    });
-    it('translates arguments', () => {
-      expectTranslate('@A(a, b) class X {}').to.equal(' @ A ( a , b ) class X { }');
-    });
-    it('translates on functions', () => {
-      expectTranslate('@A function f() {}').to.equal(' @ A f ( ) { }');
-    });
-    it('translates on properties', () => {
-      expectTranslate('class X { @A p; }').to.equal(' class X { @ A var p ; }');
-    });
-    it('translates on parameters', () => {
-      expectTranslate('function f (@A p) {}').to.equal(' f ( @ A p ) { }');
-    });
+    it('translates plain decorators',
+       () => { expectTranslate('@A class X {}').to.equal(' @ A class X { }'); });
+    it('translates arguments',
+       () => { expectTranslate('@A(a, b) class X {}').to.equal(' @ A ( a , b ) class X { }'); });
+    it('translates on functions',
+       () => { expectTranslate('@A function f() {}').to.equal(' @ A f ( ) { }'); });
+    it('translates on properties',
+       () => { expectTranslate('class X { @A p; }').to.equal(' class X { @ A var p ; }'); });
+    it('translates on parameters',
+       () => { expectTranslate('function f (@A p) {}').to.equal(' f ( @ A p ) { }'); });
   });
 
   describe('functions', () => {
@@ -311,15 +304,15 @@ describe('transpile to dart', () => {
       expectTranslate('if (x) 1; else 2;').to.equal(' if ( x ) 1 ; else 2 ;');
     });
     it('translates try/catch', () => {
-      expectTranslate('try {} catch(e) {} finally {}').to.equal(' try { } catch ( e ) { } finally { }');
-      expectTranslate('try {} catch(e: MyException) {}').to.equal(' try { } on MyException catch ( e ) { }');
+      expectTranslate('try {} catch(e) {} finally {}')
+          .to.equal(' try { } catch ( e ) { } finally { }');
+      expectTranslate('try {} catch(e: MyException) {}')
+          .to.equal(' try { } on MyException catch ( e ) { }');
     });
     it('translates throw', () => {
       expectTranslate('throw new Error("oops")').to.equal(' throw new Error ( "oops" ) ;');
     });
-    it('translates empty statements', () => {
-      expectTranslate(';').to.equal(' ;');
-    });
+    it('translates empty statements', () => { expectTranslate(';').to.equal(' ;'); });
     it('translates break & continue', () => {
       expectTranslate('break;').to.equal(' break ;');
       expectTranslate('continue;').to.equal(' continue ;');

--- a/test/e2e/lib.ts
+++ b/test/e2e/lib.ts
@@ -14,7 +14,5 @@ class MyClass {
     }
   }
 
-  namedParam({x = "?"}) {
-    return 'hello' + x;
-  }
+  namedParam({x = "?"}) { return 'hello' + x; }
 }


### PR DESCRIPTION
We need a better mechanism to prevent regressions. Should the check-format task be configured to fail now? It would be nicer to fail later in the dev workflow, like a separate warning on the PR
