### PR TITLE
Correctly escape escape sequences in template literals.

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -738,9 +738,7 @@ class Translator {
         if (arrowFunc.body.kind == ts.SyntaxKind.Block) {
           this.visitFunctionLike(arrowFunc);
         } else {
-          this.emit('(');
-          this.visitList(arrowFunc.parameters);
-          this.emit(')');
+          this.visitParameters(arrowFunc);
           this.emit('=>');
           this.visit(arrowFunc.body);
         }

--- a/main.ts
+++ b/main.ts
@@ -228,7 +228,7 @@ class Translator {
   }
 
   escapeTextForTemplateString(n: ts.Node): string {
-    return (<ts.StringLiteralExpression>n).text.replace(/([\$'])/g, '\\$1');
+    return (<ts.StringLiteralExpression>n).text.replace(/\\/g, '\\\\').replace(/([$'])/g, '\\$1');
   }
 
   visitVariableDeclarationType(varDecl: ts.VariableDeclaration) {

--- a/test/DartTest.ts
+++ b/test/DartTest.ts
@@ -251,6 +251,8 @@ describe('transpile to dart', () => {
     it('translates fat arrow operator', () => {
       expectTranslate('var a = () => {}').to.equal(' var a = ( ) { } ;');
       expectTranslate('var a = (p) => isBlank(p)').to.equal(' var a = ( p ) => isBlank ( p ) ;');
+      expectTranslate('var a = (p = null) => isBlank(p)')
+          .to.equal(' var a = ( [ p = null ] ) => isBlank ( p ) ;');
     });
   });
 

--- a/test/DartTest.ts
+++ b/test/DartTest.ts
@@ -277,6 +277,10 @@ describe('transpile to dart', () => {
       expectTranslate("`\\$a`").to.equal(" '''\\$a''' ;");
     });
 
+    it('escapes escape sequences', () => {
+      expectTranslate("`\\\\u1234`").to.equal(" '''\\\\u1234''' ;");
+    });
+
     it('translates boolean literals', () => {
       expectTranslate('true').to.equal(' true ;');
       expectTranslate('false').to.equal(' false ;');


### PR DESCRIPTION
Fixes #79.
