### PR TITLE
Refactor the fs layout before refactoring main.ts.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Compiled JS
-release
+build
 
 # Logs
 logs

--- a/.npmignore
+++ b/.npmignore
@@ -3,3 +3,5 @@ typings
 .clang-format
 .travis.yml
 tsd.json
+build/test
+build/e2e

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,6 +1,7 @@
 require('source-map-support').install();
 
 var formatter = require('gulp-clang-format');
+var fs = require('fs');
 var fsx = require('fs-extra');
 var gulp = require('gulp');
 var gutil = require('gulp-util');
@@ -8,8 +9,6 @@ var merge = require('merge2');
 var mocha = require('gulp-mocha');
 var sourcemaps = require('gulp-sourcemaps');
 var spawn = require('child_process').spawn;
-var tmpdir = require('os').tmpdir;
-var temp = require('temp');  //.track();  // track => delete temp files on exit.
 var ts = require('gulp-typescript');
 var which = require('which');
 
@@ -26,7 +25,7 @@ var TSC_OPTIONS = {
 var tsProject = ts.createProject(TSC_OPTIONS);
 
 gulp.task('test.check-format', function() {
-  return gulp.src(['*.js', '*.ts', 'test/**/*.ts']).pipe(formatter.checkFormat('file'));
+  return gulp.src(['*.js', 'lib/**/*.ts', 'test/**/*.ts']).pipe(formatter.checkFormat('file'));
 });
 
 var hasCompileError;
@@ -42,15 +41,15 @@ var onCompileError = function(err) {
 
 gulp.task('compile', function() {
   hasCompileError = false;
-  var tsResult = gulp.src(['*.ts', 'typings/**/*.d.ts'])
+  var tsResult = gulp.src(['lib/**/*.ts', 'typings/**/*.d.ts'])
                      .pipe(sourcemaps.init())
                      .pipe(ts(tsProject))
                      .on('error', onCompileError);
   return merge([
-    tsResult.dts.pipe(gulp.dest('release/definitions')),
+    tsResult.dts.pipe(gulp.dest('build/definitions')),
     // Write external sourcemap next to the js file
-    tsResult.js.pipe(sourcemaps.write('.')).pipe(gulp.dest('release/js')),
-    tsResult.js.pipe(gulp.dest('release/js')),
+    tsResult.js.pipe(sourcemaps.write('.')).pipe(gulp.dest('build/lib')),
+    tsResult.js.pipe(gulp.dest('build/lib')),
   ]);
 });
 
@@ -59,12 +58,12 @@ gulp.task('test.compile', ['compile'], function(done) {
     done();
     return;
   }
-  return gulp.src(['test/*.ts', '*.ts', 'typings/**/*.d.ts'])
+  return gulp.src(['test/*.ts', 'lib/**/*.ts', 'typings/**/*.d.ts'])
       .pipe(sourcemaps.init())
       .pipe(ts(tsProject))
       .on('error', onCompileError)
       .js.pipe(sourcemaps.write())
-      .pipe(gulp.dest('release/js/test'));
+      .pipe(gulp.dest('build/test'));
 });
 
 gulp.task('test.unit', ['test.compile'], function(done) {
@@ -72,20 +71,20 @@ gulp.task('test.unit', ['test.compile'], function(done) {
     done();
     return;
   }
-  return gulp.src('release/js/test/*.js').pipe(mocha());
+  return gulp.src('build/test/**/*.js').pipe(mocha());
 });
 
 // This test transpiles some unittests to dart and runs them in the Dart VM.
 gulp.task('test.e2e', ['test.compile'], function(done) {
   var testfile = 'helloworld';
 
-  // Set up the test env in a hermetic tmp dir
-  var dir = temp.mkdirSync('ts2dart');
-  gutil.log('E2E test files generated in', dir);
+  var dir = __dirname + '/build/e2e';
+  if (fs.existsSync(dir)) fsx.removeSync(dir);
+  fs.mkdirSync(dir);
   fsx.copySync(__dirname + '/test/e2e', dir);
 
   // run node with a shell so we can wildcard all the .ts files
-  spawn('sh', ['-c', 'node release/js/main.js ' + dir + '/*.ts'], {stdio: 'inherit'})
+  spawn('sh', ['-c', 'node build/lib/main.js ' + dir + '/*.ts'], {stdio: 'inherit'})
       .on('close', function(code, signal) {
         if (code > 0) {
           onCompileError(new Error("Failed to transpile " + testfile + '.ts'));
@@ -105,16 +104,14 @@ gulp.task('test.e2e', ['test.compile'], function(done) {
           }
         }
       });
-
-
 });
 
 gulp.task('test', ['test.unit', 'test.check-format', 'test.e2e']);
 
 gulp.task('watch', ['test.unit'], function() {
   failOnError = false;
-  // Avoid watching generated .d.ts in the release (aka output) directory.
-  return gulp.watch(['*.ts', 'test/**/*.ts'], {ignoreInitial: true}, ['test.unit']);
+  // Avoid watching generated .d.ts in the build (aka output) directory.
+  return gulp.watch(['lib/**/*.ts', 'test/**/*.ts'], {ignoreInitial: true}, ['test.unit']);
 });
 
 gulp.task('default', ['compile']);

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -1,6 +1,6 @@
-/// <reference path="typings/node/node.d.ts" />
+/// <reference path="../typings/node/node.d.ts" />
 // Use HEAD version of typescript, installed by npm
-/// <reference path="node_modules/typescript/bin/typescript.d.ts" />
+/// <reference path="../node_modules/typescript/bin/typescript.d.ts" />
 require('source-map-support').install();
 import ts = require("typescript");
 import fs = require("fs");

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ts2dart",
   "version": "0.1.6",
   "description": "Transpile TypeScript code to Dart",
-  "main": "release/js/main.js",
+  "main": "build/lib/main.js",
   "directories": {
     "test": "test"
   },

--- a/test/DartTest.ts
+++ b/test/DartTest.ts
@@ -6,7 +6,7 @@ import sms = require('source-map-support');
 sms.install();
 
 import chai = require('chai');
-import main = require('../main');
+import main = require('../lib/main');
 import ts = require('typescript');
 
 describe('transpile to dart', () => {


### PR DESCRIPTION
Move sources into a "lib" subdir (just main.ts for now).
Rename release -> build.
Produce source in build/src so that references from tests work.
Don't use a tmpdir for e2e tests.
