### PR TITLE
const for collection literals in annotations.

### DIFF
--- a/lib/main.ts
+++ b/lib/main.ts
@@ -214,6 +214,13 @@ export class Transpiler {
     });
   }
 
+  hasAncestor(n: ts.Node, kind: ts.SyntaxKind): boolean {
+    for (var parent = n; parent; parent = parent.parent) {
+      if (parent.kind === kind) return true;
+    }
+    return false;
+  }
+
   hasAnnotation(decorators: ts.NodeArray<ts.Decorator>, name: string): boolean {
     return decorators && decorators.some((d) => {
       var decName = this.ident(d.expression);
@@ -731,11 +738,13 @@ export class Transpiler {
         if (span.literal) this.visit(span.literal);
         break;
       case ts.SyntaxKind.ArrayLiteralExpression:
+        if (this.hasAncestor(node, ts.SyntaxKind.Decorator)) this.emit('const');
         this.emit('[');
         this.visitList((<ts.ArrayLiteralExpression>node).elements);
         this.emit(']');
         break;
       case ts.SyntaxKind.ObjectLiteralExpression:
+        if (this.hasAncestor(node, ts.SyntaxKind.Decorator)) this.emit('const');
         this.emit('{');
         this.visitList((<ts.ObjectLiteralExpression>node).properties);
         this.emit('}');

--- a/test/DartTest.ts
+++ b/test/DartTest.ts
@@ -202,6 +202,10 @@ describe('transpile to dart', () => {
        () => { expectTranslate('@A class X {}').to.equal(' @ A class X { }'); });
     it('translates arguments',
        () => { expectTranslate('@A(a, b) class X {}').to.equal(' @ A ( a , b ) class X { }'); });
+    it('translates const arguments', () => {
+      expectTranslate('@A([1]) class X {}').to.equal(' @ A ( const [ 1 ] ) class X { }');
+      expectTranslate('@A({"a": 1}) class X {}').to.equal(' @ A ( const { "a" : 1 } ) class X { }');
+    });
     it('translates on functions',
        () => { expectTranslate('@A function f() {}').to.equal(' @ A f ( ) { }'); });
     it('translates on properties',


### PR DESCRIPTION
Annotation arguments must be const in Dart. Special case object and
array literals if they are somewhere within a decorator tree.

Fixes #108.
