### PR TITLE
Fix the Angular build.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts2dart",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Transpile TypeScript code to Dart",
   "main": "build/lib/main.js",
   "directories": {

--- a/test/DartTest.ts
+++ b/test/DartTest.ts
@@ -535,6 +535,9 @@ describe('transpile to dart', () => {
     it('allows named export declarations', () => {
       expectTranslate('export {a, b} from "X";').to.equal(' export "package:X.dart" show a , b ;');
     });
+    it('fails for exports without URLs', () => {
+      expectErroneousCode('export {a as b};').to.throw('re-exports must have a module URL');
+    });
   });
 
   describe('errors', () => {


### PR DESCRIPTION
Ignore non .js/.ts files to avoid transpiling Angular's .es6 shims.
Fail in a more understandable way for "export {x as y}".
Bump version for a new release.
