### PR TITLE
Target ES6.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -10,19 +10,18 @@ var mocha = require('gulp-mocha');
 var sourcemaps = require('gulp-sourcemaps');
 var spawn = require('child_process').spawn;
 var ts = require('gulp-typescript');
+var typescript = require('typescript');
 var which = require('which');
 
 var TSC_OPTIONS = {
   module: "commonjs",
-  // allow pulling in files from node_modules
-  // until TS 1.5 is in tsd / DefinitelyTyped
-  // (the alternative is to include node_modules paths
-  // in the src arrays below for compilation)
+  // allow pulling in files from node_modules until TS 1.5 is in tsd / DefinitelyTyped (the
+  // alternative is to include node_modules paths in the src arrays below for compilation)
   noExternalResolve: false,
   declarationFiles: true,
   noEmitOnError: true,
-  // TypeScript's own typings (which we require) use ES6 `let` statements.
-  target: 'ES6',
+  // Specify the TypeScript version we're using.
+  typescript: typescript,
 };
 var tsProject = ts.createProject(TSC_OPTIONS);
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -21,6 +21,8 @@ var TSC_OPTIONS = {
   noExternalResolve: false,
   declarationFiles: true,
   noEmitOnError: true,
+  // TypeScript's own typings (which we require) use ES6 `let` statements.
+  target: 'ES6',
 };
 var tsProject = ts.createProject(TSC_OPTIONS);
 


### PR DESCRIPTION
This fixes the build as TSC started compiling about `let` statements in
ES5 targeting code. `typescript.d.ts` itself contains `let` statements,
so we have to move to ES6.

Also explicitly pass in the TypeScript dependency to make sure our
dependency versions are half-way sane.
