### PR TITLE
Clean up the API

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "test": "test"
   },
   "dependencies": {
+    "fs-extra": "^0.18.0",
     "source-map": "^0.4.2",
     "source-map-support": "^0.2.9",
     "typescript": "Microsoft/TypeScript#cebe42b81fbeeaf68c8e228dda5e602ab94e151b"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts2dart",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Transpile TypeScript code to Dart",
   "main": "build/lib/main.js",
   "directories": {

--- a/tsd.json
+++ b/tsd.json
@@ -19,6 +19,9 @@
     },
     "source-map/source-map.d.ts": {
       "commit": "2520bce9a8a71b66e67487cbd5b33fec880b0c55"
+    },
+    "fs-extra/fs-extra.d.ts": {
+      "commit": "d5f92f93bdb49f332fa662ff1d0cc8700f02e4dc"
     }
   }
 }


### PR DESCRIPTION
- provide a single entry point function that takes files, output directory, and options (ts2dart.transpile()).
- use a basePath to create relative file names
- use relative names for library names and errors
- make most methods and fields private
