### PR TITLE
Special case types ending in *Annotation.

### DIFF
--- a/lib/base.ts
+++ b/lib/base.ts
@@ -75,6 +75,7 @@ export class TranspilerStep {
       return;
     }
     var identifier = ident(typeName);
+    identifier = identifier.replace(/(.+)Annotation$/, '$1');
     var translated = TranspilerStep.DART_TYPES[identifier] || identifier;
     this.emit(translated);
   }

--- a/lib/declaration.ts
+++ b/lib/declaration.ts
@@ -51,7 +51,7 @@ class DeclarationTranspiler extends base.TranspilerStep {
           this.reportError(node, 'const enums are not supported');
         }
         this.emit('enum');
-        this.visit(decl.name);
+        this.visitTypeName(decl.name);
         this.emit('{');
         // Enums can be empty in TS ...
         if (decl.members.length === 0) {
@@ -267,7 +267,7 @@ class DeclarationTranspiler extends base.TranspilerStep {
   private visitClassLike(keyword: string, decl: ClassLike) {
     this.visitDecorators(decl.decorators);
     this.emit(keyword);
-    this.visit(decl.name);
+    this.visitTypeName(decl.name);
     if (decl.typeParameters) {
       this.emit('<');
       this.visitList(decl.typeParameters);

--- a/test/decorator_test.ts
+++ b/test/decorator_test.ts
@@ -52,4 +52,15 @@ describe('decorators', () => {
     expectTranslate('@IMPLEMENTS(Z) class X implements Y {}')
         .to.equal(' @ IMPLEMENTS ( Z ) class X implements Y , Z { }');
   });
+
+});
+
+describe('annotation/decorator hack', () => {
+  it('should strip "Annotation" from type names', () => {
+    expectTranslate('@CONST class FooAnnotation {}').to.equal(' @ CONST const class Foo { }');
+  });
+  it('should strip "Annotation" from imports', () => {
+    expectTranslate('import {FooAnnotation} from "foo";')
+        .to.equal(' import "package:foo.dart" show Foo ;');
+  });
 });


### PR DESCRIPTION
This allows using decorators in TypeScript code and transpiling them to
annotations in Dart. It's still required to put @CONST annotations on the
annotation classes themselves.
