### PR TITLE
feat(ts2dart): support property parameter shorthand.

### DIFF
--- a/test/declaration_test.ts
+++ b/test/declaration_test.ts
@@ -101,6 +101,14 @@ describe('classes', () => {
     it('supports constructors', () => {
       expectTranslate('class X { constructor() { } }').to.equal(' class X { X ( ) { } }');
     });
+    it('supports parameter properties', () => {
+      expectTranslate(
+          'class X { c: number; constructor(private bar: B, public foo: string = "hello") {} }')
+          .to.equal(
+              ' class X { B bar ; String foo = \"hello\" ; num c ; X ( this . bar , [ this . foo ] ) { } }');
+      expectTranslate('@CONST class X { constructor(public foo: string, b: number) {} }')
+          .to.equal(' @ CONST class X { final String foo ; const X ( this . foo , num b ) ; }');
+    });
   });
 });
 

--- a/test/e2e/lib.ts
+++ b/test/e2e/lib.ts
@@ -1,15 +1,13 @@
 @CONST
 class MyClass {
-  private _field: string;
-
-  constructor(someVal: string) { this._field = someVal; }
+  constructor(private someVal: string) {}
 
   get field(): string {
     // TODO: TypeScript doesn't parse the RHS as StringKeyword so we lose
     // the translation of string -> String.
     // We use capital S String here, even though it wouldn't run in TS.
     if (" world" instanceof String) {
-      return this._field + " world";
+      return this.someVal + " world";
     } else {
       return "error";
     }


### PR DESCRIPTION
This lets us declare properties in the constructor parameters in TypeScript code,
and emits explicit property declarations and the "this.prop" constructor param
which is the equivalent Dart shorthand.

Fixes #15
