### PR TITLE
feat(const): Translate CONST_EXPR to const expressions.

### DIFF
--- a/lib/call.ts
+++ b/lib/call.ts
@@ -40,7 +40,14 @@ class CallTranspiler extends base.TranspilerStep {
   }
 
   private visitCall(c: ts.CallExpression) {
-    this.visit(c.expression);
+    var fnName = base.ident(c.expression);
+    if (fnName === 'CONST_EXPR') {
+      // The special function CONST_EXPR translates to Dart's const expressions.
+      this.emit('const');
+      if (c.arguments.length !== 1) this.reportError(c, 'CONST_EXPR takes exactly one argument');
+    } else {
+      this.visit(c.expression);
+    }
     this.emit('(');
     if (!this.handleNamedParamsCall(c)) {
       this.visitList(c.arguments);

--- a/lib/declaration.ts
+++ b/lib/declaration.ts
@@ -364,10 +364,9 @@ class DeclarationTranspiler extends base.TranspilerStep {
   private visitDecorators(decorators: ts.NodeArray<ts.Decorator>) {
     if (!decorators) return;
 
-    var isAbstract = false, isConst = false;
+    var isAbstract = false;
     decorators.forEach((d) => {
-      // Special case @CONST & @ABSTRACT
-      // TODO(martinprobst): remove once the code base is migrated to TypeScript.
+      // Special case @CONST, @IMPLEMENTS, & @ABSTRACT
       var name = base.ident(d.expression);
       if (!name && d.expression.kind === ts.SyntaxKind.CallExpression) {
         // Unwrap @CONST()
@@ -375,15 +374,14 @@ class DeclarationTranspiler extends base.TranspilerStep {
         name = base.ident(callExpr.expression);
       }
       // Make sure these match IGNORED_ANNOTATIONS below.
-      // TODO(martinprobst): Re-enable the early exits below once moved to TypeScript.
       if (name === 'ABSTRACT') {
         isAbstract = true;
-        // this.emit('abstract');
-        // return;
+        return;
       }
       if (name === 'CONST' || name === 'IMPLEMENTS') {
         // Ignore @IMPLEMENTS and @CONST - they are handled above in visitClassLike.
-        // return;
+        // TODO(martinprobst): @IMPLEMENTS should be removed as TS supports it natively.
+        return;
       }
       this.emit('@');
       this.visit(d.expression);

--- a/test/call_test.ts
+++ b/test/call_test.ts
@@ -42,4 +42,10 @@ describe('calls', () => {
     expectTranslate('class X { y() { super.z(1); } }')
         .to.equal(' class X { y ( ) { super . z ( 1 ) ; } }');
   });
+
+  it('translates CONST_EXPR(...) to const (...)', () => {
+    expectTranslate('const x = CONST_EXPR([]);').to.equal(' const x = const ( [ ] ) ;');
+    expectErroneousCode('CONST_EXPR()').to.throw(/exactly one argument/);
+    expectErroneousCode('CONST_EXPR(1, 2)').to.throw(/exactly one argument/);
+  });
 });

--- a/test/call_test.ts
+++ b/test/call_test.ts
@@ -44,7 +44,9 @@ describe('calls', () => {
   });
 
   it('translates CONST_EXPR(...) to const (...)', () => {
-    expectTranslate('const x = CONST_EXPR([]);').to.equal(' const x = const ( [ ] ) ;');
+    expectTranslate('import {CONST_EXPR} from "angular2/facade/lang.ts";\n' +
+                    'const x = CONST_EXPR([]);')
+        .to.equal(' const x = const ( [ ] ) ;');
     expectErroneousCode('CONST_EXPR()').to.throw(/exactly one argument/);
     expectErroneousCode('CONST_EXPR(1, 2)').to.throw(/exactly one argument/);
   });

--- a/test/declaration_test.ts
+++ b/test/declaration_test.ts
@@ -107,7 +107,7 @@ describe('classes', () => {
           .to.equal(
               ' class X { B bar ; String foo ; num c ; X ( this . bar , [ this . foo = \"hello\" ] ) { } }');
       expectTranslate('@CONST class X { constructor(public foo: string, b: number) {} }')
-          .to.equal(' @ CONST class X { final String foo ; const X ( this . foo , num b ) ; }');
+          .to.equal(' class X { final String foo ; const X ( this . foo , num b ) ; }');
     });
   });
 });

--- a/test/decorator_test.ts
+++ b/test/decorator_test.ts
@@ -18,21 +18,21 @@ describe('decorators', () => {
   it('translates on parameters',
      () => { expectTranslate('function f (@A p) {}').to.equal(' f ( @ A p ) { }'); });
   it('special cases @CONST', () => {
-    expectTranslate('@CONST class X {}').to.equal(' @ CONST class X { const X (); }');
-    expectTranslate('@CONST() class X {}').to.equal(' @ CONST ( ) class X { const X (); }');
+    expectTranslate('@CONST class X {}').to.equal(' class X { const X (); }');
+    expectTranslate('@CONST() class X {}').to.equal(' class X { const X (); }');
     expectTranslate(`@CONST class X {
                        x: number;
                        y;
                        constructor() { super(3); this.x = 1; this.y = 2; }
                      }`)
-        .to.equal(' @ CONST class X {' +
+        .to.equal(' class X {' +
                   ' final num x ; final y ;' +
                   ' const X ( ) : x = 1 , y = 2 , super ( 3 ) ; }');
     expectTranslate('@CONST class X { constructor() {} }')
-        .to.equal(' @ CONST class X { const X ( ) ; }');
+        .to.equal(' class X { const X ( ) ; }');
     // For backwards-compatibility for traceur inputs (not valid TS input)
     expectTranslate('class X { @CONST constructor() {} }')
-        .to.equal(' class X { @ CONST const X ( ) ; }');
+        .to.equal(' class X { const X ( ) ; }');
     expectErroneousCode('@CONST class X { constructor() { if (1); } }')
         .to.throw('const constructors can only contain assignments and super calls');
     expectErroneousCode('@CONST class X { constructor() { f(); } }')
@@ -45,14 +45,14 @@ describe('decorators', () => {
         .to.throw('assignments in const constructors must assign into this.');
   });
   it('special cases @ABSTRACT', () => {
-    expectTranslate('@ABSTRACT class X {}').to.equal(' @ ABSTRACT abstract class X { }');
+    expectTranslate('@ABSTRACT class X {}').to.equal(' abstract class X { }');
   });
   it('special cases @IMPLEMENTS', () => {
     expectTranslate('@IMPLEMENTS(Y, Z) class X {}')
-        .to.equal(' @ IMPLEMENTS ( Y , Z ) class X implements Y , Z { }');
+        .to.equal(' class X implements Y , Z { }');
     expectTranslate('@IMPLEMENTS(Z) class X extends Y {}')
-        .to.equal(' @ IMPLEMENTS ( Z ) class X extends Y implements Z { }');
+        .to.equal(' class X extends Y implements Z { }');
     expectTranslate('@IMPLEMENTS(Z) class X implements Y {}')
-        .to.equal(' @ IMPLEMENTS ( Z ) class X implements Y , Z { }');
+        .to.equal(' class X implements Y , Z { }');
   });
 });

--- a/test/module_test.ts
+++ b/test/module_test.ts
@@ -19,9 +19,8 @@ describe('imports', () => {
     expectTranslate('import {x} from "./y"').to.equal(' import "y.dart" show x ;');
     expectTranslate('import {x} from "../y"').to.equal(' import "../y.dart" show x ;');
   });
-  // TODO(martinprobst): Re-enable once moved to TypeScrip
-  it.skip('handles ignored annotations in imports', () => {
-    expectTranslate('import {CONST, IMPLEMENTS} from "x"').to.equal('');
+  it('handles ignored annotations in imports', () => {
+    expectTranslate('import {CONST, CONST_EXPR, IMPLEMENTS, ABSTRACT} from "x"').to.equal('');
     expectTranslate('import {x, IMPLEMENTS} from "./x"').to.equal(' import "x.dart" show x ;');
   });
 });


### PR DESCRIPTION
This allows to construct compile time literal (const) expressions in Dart, e.g.

```
const bools = CONST_EXPR([true, false, FileNotFound]);
```
