### PR TITLE
chore(types): Switch to --noImplicitAny mode.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -18,6 +18,7 @@ var TSC_OPTIONS = {
   // allow pulling in files from node_modules until TS 1.5 is in tsd / DefinitelyTyped (the
   // alternative is to include node_modules paths in the src arrays below for compilation)
   noExternalResolve: false,
+  noImplicitAny: true,
   declarationFiles: true,
   noEmitOnError: true,
   // Specify the TypeScript version we're using.

--- a/lib/base.ts
+++ b/lib/base.ts
@@ -71,7 +71,7 @@ export class TranspilerStep {
   // TODO(martinprobst): This belongs to module.ts, refactor.
   getLibraryName(): string { return this.transpiler.getLibraryName(); }
 
-  private static DART_TYPES = {
+  private static DART_TYPES: {[k: string]: string} = {
     'Promise': 'Future',
     'Observable': 'Stream',
     'ObservableController': 'StreamController',

--- a/lib/call.ts
+++ b/lib/call.ts
@@ -107,8 +107,8 @@ class CallTranspiler extends base.TranspilerStep {
     var errorThisAssignment = 'assignments in const constructors must assign into this.';
 
     var parent = <base.ClassLike>ctor.parent;
-    var superCall;
-    var expressions = [];
+    var superCall: ts.CallExpression;
+    var expressions: ts.Expression[] = [];
     // Find super() calls and (if in a const ctor) collect assignment expressions (not statements!)
     body.statements.forEach((stmt) => {
       if (stmt.kind !== ts.SyntaxKind.ExpressionStatement) {

--- a/lib/declaration.ts
+++ b/lib/declaration.ts
@@ -74,7 +74,7 @@ class DeclarationTranspiler extends base.TranspilerStep {
       case ts.SyntaxKind.Constructor:
         var ctorDecl = <ts.ConstructorDeclaration>node;
         // Find containing class name.
-        var className;
+        var className: ts.Identifier;
         for (var parent = ctorDecl.parent; parent; parent = parent.parent) {
           if (parent.kind == ts.SyntaxKind.ClassDeclaration) {
             className = (<ts.ClassDeclaration>parent).name;
@@ -244,8 +244,8 @@ class DeclarationTranspiler extends base.TranspilerStep {
 
   private visitParameters(parameters: ts.ParameterDeclaration[]) {
     this.emit('(');
-    let firstInitParamIdx;
-    for (firstInitParamIdx = 0; firstInitParamIdx < parameters.length; firstInitParamIdx++) {
+    let firstInitParamIdx = 0;
+    for (; firstInitParamIdx < parameters.length; firstInitParamIdx++) {
       // ObjectBindingPatterns are handled within the parameter visit.
       let isOpt =
           parameters[firstInitParamIdx].initializer || parameters[firstInitParamIdx].questionToken;
@@ -346,7 +346,7 @@ class DeclarationTranspiler extends base.TranspilerStep {
 
   /** Returns the parameters passed to @IMPLEMENTS as the identifier's string values. */
   private getImplementsDecorators(decorators: ts.NodeArray<ts.Decorator>): string[] {
-    var interfaces = [];
+    var interfaces: string[] = [];
     if (!decorators) return interfaces;
     decorators.forEach((d) => {
       if (d.expression.kind !== ts.SyntaxKind.CallExpression) return;

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -227,7 +227,7 @@ class Output {
   private generateSourceMap: boolean;
   private sourceMap: SourceMap.SourceMapGenerator;
 
-  constructor(private currentFile: ts.SourceFile, private relativeFileName,
+  constructor(private currentFile: ts.SourceFile, private relativeFileName: string,
               generateSourceMap: boolean) {
     if (generateSourceMap) {
       this.sourceMap = new SourceMap.SourceMapGenerator({file: relativeFileName + '.dart'});

--- a/test/e2e/helloworld.ts
+++ b/test/e2e/helloworld.ts
@@ -1,6 +1,7 @@
 import t = require("unittest/unittest");
 import {MyClass, SomeArray} from './lib';
 
+
 function main(): void {
   t.test("handles classes", function() {
     var mc = new MyClass("hello");

--- a/test/main_test.ts
+++ b/test/main_test.ts
@@ -56,7 +56,7 @@ describe('main transpiler functionality', () => {
     beforeEach(() => {
       transpiler = new main.Transpiler({generateSourceMap: true, basePath: '/absolute/'});
     });
-    function translateMap(source) {
+    function translateMap(source: string) {
       var program = parseProgram(source, '/absolute/path/test.ts');
       return transpiler.translateProgram(program);
     }

--- a/test/module_test.ts
+++ b/test/module_test.ts
@@ -44,7 +44,7 @@ describe('exports', () => {
 });
 
 describe('library name', () => {
-  var transpiler;
+  var transpiler: main.Transpiler;
   beforeEach(() => {
     transpiler = new main.Transpiler({failFast: true, generateLibraryName: true, basePath: '/a'});
   });


### PR DESCRIPTION
This disallows expressions to have implicit "any" types, i.e. expressions must
have their type inferred or must be typed. We should try this mode out a bit
and see if it's useful or problematic, as a test bed for Angular and other
places.
