### PR TITLE
chore(build): do not install and run tsd on every install.

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,7 @@
     "which": "^1.0.9"
   },
   "scripts": {
-    "preinstall": "npm install tsd@^0.5.7 && tsd reinstall",
-    "prepublish": "gulp compile",
+    "prepublish": "npm install tsd@^0.5.7 && tsd reinstall && gulp compile",
     "test": "gulp test"
   },
   "repository": {


### PR DESCRIPTION
Install scripts are run by every user on every install, but ts2dart users do not actually need tsd or the type definitions, as we ship compiled JavaScript. This should speed up downstream project builds.
