### PR TITLE
feat: Add a tsconfig.json.

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "noImplicitAny": true,
+    "noEmit": true,
+  },
+}


### PR DESCRIPTION
This is a minimal configuration to get rid of warnings about not specifying a
module system in SublimeText. It disables emitting, as this is handled by the
actual build running via gulp.
