### PR TITLE
fix(build): run test.e2e on Windows

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -82,7 +82,8 @@ gulp.task('test.unit', ['test.compile'], function(done) {
 gulp.task('test.e2e', ['test.compile'], function(done) {
   var testfile = 'helloworld';
 
-  var dir = __dirname + '/build/e2e';
+  // Removes backslashes from __dirname in Windows
+  var dir = (__dirname.replace(/\\/g, '/') + '/build/e2e');
   if (fs.existsSync(dir)) fsx.removeSync(dir);
   fs.mkdirSync(dir);
   fsx.copySync(__dirname + '/test/e2e', dir);


### PR DESCRIPTION
With this PR and the recent changes in the project, only `gulp test.check-format' still fails on Windows. 
Maybe due to a different binary in clang-format ?

The error is not very explicit:

```
[18:16:43] Error: no writecb in Transform class
    at afterTransform (d:\Github\ts2dart_mlaval\node_modules\gulp-clang-format\node_modules\through2\node_modules\readable-stream\lib\_stream_transform.js:95:33)
    at TransformState.afterTransform (d:\Github\ts2dart_mlaval\node_modules\gulp-clang-format\node_modules\through2\node_modules\readable-stream\lib\_stream_transform.js:79:12)
    at ChildProcess.<anonymous> (d:\Github\ts2dart_mlaval\node_modules\gulp-clang-format\node_modules\clang-format\index.js:37:15)
    at ChildProcess.emit (events.js:110:17)
    at maybeClose (child_process.js:1015:16)
    at Socket.<anonymous> (child_process.js:1183:11)
    at Socket.emit (events.js:107:17)
    at Pipe.close (net.js:485:12)
```
