### PR TITLE
fix(bug): dart abstract methods don't use abstract keyword

### DIFF
--- a/lib/declaration.ts
+++ b/lib/declaration.ts
@@ -133,7 +133,6 @@ class DeclarationTranspiler extends base.TranspilerStep {
         break;
       case ts.SyntaxKind.MethodSignature:
         var methodSignatureDecl = <ts.FunctionLikeDeclaration>node;
-        this.emit('abstract');
         this.visitEachIfPresent(methodSignatureDecl.modifiers);
         this.visitFunctionLike(methodSignatureDecl);
         break;

--- a/test/declaration_test.ts
+++ b/test/declaration_test.ts
@@ -125,9 +125,8 @@ describe('interfaces', () => {
     expectTranslate('class X extends Y implements Z {}')
         .to.equal(' class X extends Y implements Z { }');
   });
-  it('supports abstract methods', () => {
-    expectTranslate('interface X { x(); }').to.equal(' abstract class X { abstract x ( ) ; }');
-  });
+  it('supports abstract methods',
+     () => { expectTranslate('interface X { x(); }').to.equal(' abstract class X { x ( ) ; }'); });
 });
 
 describe('enums', () => {

--- a/test/e2e/lib.ts
+++ b/test/e2e/lib.ts
@@ -19,9 +19,14 @@ class MyClass {
   namedParam({x = "?"}) { return 'hello' + x; }
 }
 
-class MySubclass extends MyClass {
+interface Observer {
+  update(o: Object, arg: Object);
+}
+
+class MySubclass extends MyClass implements Observer {
   constructor(_field: string) { super(_field); }
   get subclassField(): string { return this.field; }
+  update(o: Object, arg: Object) {}
 }
 
 const SomeArray = CONST_EXPR([1, 2, 3]);


### PR DESCRIPTION
fixes #165
