### PR TITLE
feat: façade converter handles various special cases for Dart.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -89,7 +89,10 @@ gulp.task('test.e2e', ['test.compile'], function(done) {
   fsx.copySync(__dirname + '/test/e2e', dir);
 
   // run node with a shell so we can wildcard all the .ts files
-  spawn('sh', ['-c', 'node build/lib/main.js ' + dir + '/*.ts'], {stdio: 'inherit'})
+  var cmd = 'node ../lib/main.js --translateBuiltins --basePath=. --destination=. ' +
+            '*.ts angular2/src/facade/lang.d.ts';
+  // Paths must be relative to our source root, so run with cwd == dir.
+  spawn('sh', ['-c', cmd], {stdio: 'inherit', cwd: dir})
       .on('close', function(code, signal) {
         if (code > 0) {
           onError(new Error("Failed to transpile " + testfile + '.ts'));

--- a/lib/base.ts
+++ b/lib/base.ts
@@ -14,7 +14,7 @@ export function ident(n: ts.Node): string {
   return null;
 }
 
-export class TranspilerStep {
+export class TranspilerBase {
   constructor(private transpiler: ts2dart.Transpiler) {}
 
   visit(n: ts.Node) { this.transpiler.visit(n); }
@@ -73,12 +73,13 @@ export class TranspilerStep {
   // TODO(martinprobst): This belongs to module.ts, refactor.
   getLibraryName(): string { return this.transpiler.getLibraryName(); }
 
-  private static DART_TYPES: {[k: string]: string} = {
+  private static TS_TO_DART_TYPENAMES: {[k: string]: string} = {
     'Promise': 'Future',
     'Observable': 'Stream',
     'ObservableController': 'StreamController',
     'Date': 'DateTime',
-    'StringMap': 'Map'
+    'StringMap': 'Map',
+    'Array': 'List',
   };
 
   visitTypeName(typeName: ts.EntityName) {
@@ -87,8 +88,8 @@ export class TranspilerStep {
       return;
     }
     var identifier = ident(typeName);
-    if (TranspilerStep.DART_TYPES.hasOwnProperty(identifier)) {
-      identifier = TranspilerStep.DART_TYPES[identifier];
+    if (TranspilerBase.TS_TO_DART_TYPENAMES.hasOwnProperty(identifier)) {
+      identifier = TranspilerBase.TS_TO_DART_TYPENAMES[identifier];
     }
     this.emit(identifier);
   }

--- a/lib/declaration.ts
+++ b/lib/declaration.ts
@@ -3,7 +3,7 @@ import ts = require('typescript');
 import base = require('./base');
 import ts2dart = require('./main');
 
-class DeclarationTranspiler extends base.TranspilerStep {
+class DeclarationTranspiler extends base.TranspilerBase {
   constructor(tr: ts2dart.Transpiler) { super(tr); }
 
   visitNode(node: ts.Node): boolean {

--- a/lib/expression.ts
+++ b/lib/expression.ts
@@ -2,9 +2,10 @@
 import ts = require('typescript');
 import base = require('./base');
 import ts2dart = require('./main');
+import {FacadeConverter} from './facade_converter';
 
-class ExpressionTranspiler extends base.TranspilerStep {
-  constructor(tr: ts2dart.Transpiler) { super(tr); }
+class ExpressionTranspiler extends base.TranspilerBase {
+  constructor(tr: ts2dart.Transpiler, private fc: FacadeConverter) { super(tr); }
 
   visitNode(node: ts.Node): boolean {
     switch (node.kind) {
@@ -72,6 +73,7 @@ class ExpressionTranspiler extends base.TranspilerStep {
             this.hasAncestor(propAccess, ts.SyntaxKind.CatchClause)) {
           this.emitNoSpace('_stack');
         } else {
+          this.fc.checkPropertyAccess(propAccess);
           this.emit('.');
           this.visit(propAccess.name);
         }

--- a/lib/facade_converter.ts
+++ b/lib/facade_converter.ts
@@ -1,0 +1,168 @@
+/// <reference path='../node_modules/typescript/bin/typescript.d.ts' />
+import base = require('./base');
+import ts = require('typescript');
+import ts2dart = require('./main');
+
+type FacadeHandler = (c: ts.CallExpression, context: ts.Expression) => void;
+
+export class FacadeConverter extends base.TranspilerBase {
+  private tc: ts.TypeChecker;
+  private forbiddenNames: {[fileName: string]: boolean};
+
+  constructor(transpiler: ts2dart.Transpiler) {
+    super(transpiler);
+    this.forbiddenNames = {};
+    for (var fileName in this.subs) {
+      Object.keys(this.subs[fileName])
+          .map((fnName) => fnName.substring(fnName.lastIndexOf('.') + 1))
+          .forEach((fnName) => this.forbiddenNames[fnName] = true);
+    }
+  }
+
+  setTypeChecker(tc: ts.TypeChecker) { this.tc = tc; }
+
+  maybeHandleCall(c: ts.CallExpression): boolean {
+    if (!this.tc) return false;
+
+    var symbol: ts.Symbol;
+    var context: ts.Expression;
+
+    if (c.expression.kind === ts.SyntaxKind.Identifier) {
+      // Function call.
+      symbol = this.tc.getSymbolAtLocation(c.expression);
+      context = null;
+    } else if (c.expression.kind === ts.SyntaxKind.PropertyAccessExpression) {
+      // Method call.
+      var pa = <ts.PropertyAccessExpression>c.expression;
+      symbol = this.tc.getSymbolAtLocation(pa.name);
+      context = pa.expression;
+    } else {
+      // Not a call we recognize.
+      return false;
+    }
+
+    if (!symbol) {
+      var ident = base.ident(c.expression);
+      if (ident && this.forbiddenNames[ident]) this.reportMissingType(c, ident);
+      return false;
+    }
+
+    if (symbol.flags & ts.SymbolFlags.Alias) symbol = this.tc.getAliasedSymbol(symbol);
+    if (!symbol.valueDeclaration) return false;
+
+    var fileName = symbol.valueDeclaration.getSourceFile().fileName;
+    fileName = fileName.replace(/(\.d)?\.ts$/, '');
+
+    // console.log('fn:', fileName);
+    var fileSubs = this.subs[fileName];
+    var qn = this.tc.getFullyQualifiedName(symbol);
+    // Function Qualified Names include their file name. Might be a bug in TypeScript, for the
+    // time being just special case.
+    if (symbol.flags & ts.SymbolFlags.Function) qn = symbol.getName();
+
+    // console.log('qn', qn);
+
+    var qnSub = fileSubs[qn];
+    if (!qnSub) return false;
+
+    qnSub(c, context);
+    return true;
+  }
+
+  private subs: ts.Map<ts.Map<FacadeHandler>> = {
+    'lib': {
+      'Array.push': (c: ts.CallExpression, context: ts.Expression) => {
+        this.visit(context);
+        this.emitCall('add', c.arguments);
+      },
+      'Array.map': (c: ts.CallExpression, context: ts.Expression) => {
+        this.visit(context);
+        this.emitCall('map', c.arguments);
+        this.emitCall('toList');
+      },
+      'Array.forEach': (c: ts.CallExpression, context: ts.Expression) => {
+        this.visit(context);
+        this.emitCall('forEach', c.arguments);
+        this.emitCall('toList');
+      },
+      'Array.slice': (c: ts.CallExpression, context: ts.Expression) => {
+        this.emitCall('ListWrapper.slice', [context, ...c.arguments]);
+      },
+      'Array.splice': (c: ts.CallExpression, context: ts.Expression) => {
+        this.emitCall('ListWrapper.splice', [context, ...c.arguments]);
+      },
+      'Array.concat': (c: ts.CallExpression, context: ts.Expression) => {
+        this.emit('new List . from (');
+        this.visit(context);
+        this.emit(') .. addAll (');
+        this.visit(c.arguments[0]);
+        this.emit(')');
+      },
+      'Array.isArray': (c: ts.CallExpression, context: ts.Expression) => {
+        this.visit(context);
+        this.emit('is List');
+      },
+    },
+    'angular2/traceur-runtime': {
+      'Map.set': (c: ts.CallExpression, context: ts.Expression) => {
+        this.visit(context);
+        this.emit('[');
+        this.visit(c.arguments[0]);
+        this.emit(']');
+        this.emit('=');
+        this.visit(c.arguments[1]);
+      },
+      'Map.get': (c: ts.CallExpression, context: ts.Expression) => {
+        this.visit(context);
+        this.emit('[');
+        this.visit(c.arguments[0]);
+        this.emit(']');
+      },
+    },
+    'angular2/src/facade/lang': {
+      'CONST_EXPR': (c: ts.CallExpression, context: ts.Expression) => {
+        // `const` keyword is emitted in the array literal handling, as it needs to be transitive.
+        this.visitList(c.arguments);
+      },
+      'FORWARD_REF': (c: ts.CallExpression, context: ts.Expression) => {
+        // The special function FORWARD_REF translates to an unwrapped value in Dart.
+        const callback = <ts.FunctionExpression>c.arguments[0];
+        if (callback.kind !== ts.SyntaxKind.ArrowFunction) {
+          this.reportError(c, 'FORWARD_REF takes only arrow functions');
+          return;
+        }
+        this.visit(callback.body);
+      }
+    },
+  };
+
+  private emitCall(name: string, args?: ts.Expression[]) {
+    this.emit('.');
+    this.emit(name);
+    this.emit('(');
+    if (args) this.visitList(args);
+    this.emit(')');
+  }
+
+  checkPropertyAccess(pa: ts.PropertyAccessExpression) {
+    if (!this.tc) return;
+    var ident = pa.name.text;
+    if (this.forbiddenNames[ident] && !this.tc.getSymbolAtLocation(pa.name)) {
+      this.reportMissingType(pa, ident);
+    }
+  }
+
+  reportMissingType(n: ts.Node, ident: string) {
+    this.reportError(n, `Untyped property access to "${ident}" which could be special.\n` +
+                            ` Please add type declarations to disambiguate.`);
+  }
+
+  isInsideConstExpr(node: ts.Node): boolean {
+    return this.isConstCall(
+        <ts.CallExpression>this.getAncestor(node, ts.SyntaxKind.CallExpression));
+  }
+
+  private isConstCall(node: ts.CallExpression): boolean {
+    return node && base.ident(node.expression) === 'CONST_EXPR';
+  }
+}

--- a/lib/module.ts
+++ b/lib/module.ts
@@ -3,7 +3,7 @@ import ts = require('typescript');
 import base = require('./base');
 import ts2dart = require('./main');
 
-class ImportExportTranspiler extends base.TranspilerStep {
+class ImportExportTranspiler extends base.TranspilerBase {
   constructor(tr: ts2dart.Transpiler, private generateLibraryName: boolean) { super(tr); }
 
   visitNode(node: ts.Node): boolean {

--- a/lib/statement.ts
+++ b/lib/statement.ts
@@ -5,7 +5,7 @@ import ts2dart = require('./main');
 
 type ClassLike = ts.ClassDeclaration | ts.InterfaceDeclaration;
 
-class StatementTranspiler extends base.TranspilerStep {
+class StatementTranspiler extends base.TranspilerBase {
   constructor(tr: ts2dart.Transpiler) { super(tr); }
 
   visitNode(node: ts.Node): boolean {

--- a/lib/type.ts
+++ b/lib/type.ts
@@ -3,7 +3,7 @@ import ts = require('typescript');
 import base = require('./base');
 import ts2dart = require('./main');
 
-class TypeTranspiler extends base.TranspilerStep {
+class TypeTranspiler extends base.TranspilerBase {
   constructor(tr: ts2dart.Transpiler) { super(tr); }
 
   visitNode(node: ts.Node): boolean {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "fs-extra": "^0.18.0",
+    "minimist": "^1.1.1",
     "source-map": "^0.4.2",
     "source-map-support": "^0.3.1",
     "typescript": "alexeagle/TypeScript#error_is_class"

--- a/test/call_test.ts
+++ b/test/call_test.ts
@@ -42,26 +42,4 @@ describe('calls', () => {
     expectTranslate('class X { y() { super.z(1); } }')
         .to.equal(' class X { y ( ) { super . z ( 1 ) ; } }');
   });
-
-  it('translates CONST_EXPR(...) to const (...)', () => {
-    expectTranslate('import {CONST_EXPR} from "angular2/facade/lang.ts";\n' +
-                    'const x = CONST_EXPR([]);')
-        .to.equal(' const x = const [ ] ;');
-    expectTranslate('import {CONST_EXPR} from "angular2/facade/lang.ts";\n' +
-                    'const x = CONST_EXPR(new Person());')
-        .to.equal(' const x = const Person ( ) ;');
-    expectTranslate('import {CONST_EXPR} from "angular2/facade/lang.ts";\n' +
-                    'const x = CONST_EXPR({"one":1});')
-        .to.equal(' const x = const { "one" : 1 } ;');
-    expectErroneousCode('CONST_EXPR()').to.throw(/exactly one argument/);
-    expectErroneousCode('CONST_EXPR(1, 2)').to.throw(/exactly one argument/);
-  });
-
-  it('translates FORWARD_REF(() => T) to T', () => {
-    expectTranslate('import {FORWARD_REF} from "angular2/facade/lang.ts";\n' +
-                    'var x = FORWARD_REF(() => SomeType);')
-        .to.equal(' var x = SomeType ;');
-    expectErroneousCode('FORWARD_REF()').to.throw(/exactly one argument/);
-    expectErroneousCode('FORWARD_REF(1)').to.throw(/only arrow functions/);
-  });
 });

--- a/test/e2e/angular2/src/facade/lang.d.ts
+++ b/test/e2e/angular2/src/facade/lang.d.ts
@@ -1,0 +1,2 @@
+export declare function CONST_EXPR<T>(x: T): T;
+export declare function FORWARD_REF<T>(x: T): T;

--- a/test/e2e/lib.ts
+++ b/test/e2e/lib.ts
@@ -1,4 +1,4 @@
-import {CONST_EXPR, FORWARD_REF} from "somewhere";
+import {CONST_EXPR, FORWARD_REF} from "angular2/src/facade/lang";
 
 @CONST
 class MyClass {

--- a/test/facade_converter_test.ts
+++ b/test/facade_converter_test.ts
@@ -1,0 +1,96 @@
+/// <reference path="../typings/mocha/mocha.d.ts"/>
+import {parseFiles, expectTranslate, expectErroneousCode, translateSource} from './test_support';
+import chai = require('chai');
+
+var traceurRuntimeDeclarations = `
+    interface Map<K, V> {
+      clear(): void;
+      delete (key: K): boolean;
+      forEach(callbackfn: (value: V, index: K, map: Map<K, V>) => void, thisArg?: any): void;
+      keys(): List<K>;
+      values(): List<V>;
+      get(key: K): V;
+      has(key: K): boolean;
+      set(key: K, value: V): Map<K, V>;
+      size: number;
+    }
+    declare var Map: {
+      new<K, V>(): Map<K, V>;
+      // alexeagle: PATCHED
+      new<K, V>(m: Map<K, V>): Map<K, V>;
+      new<K, V>(l: List<any>): Map<K, V>;
+      prototype: Map<any, any>;
+    };`;
+
+var langDeclarations = `
+  export declare function CONST_EXPR<T>(x: T): T;
+  export declare function FORWARD_REF<T>(x: T): T;
+  `;
+
+function expectWithTypes(str: string) {
+  return expectTranslate(
+      {
+        'main.ts': str,
+        'angular2/traceur-runtime.d.ts': traceurRuntimeDeclarations,
+        'angular2/src/facade/lang.d.ts': langDeclarations,
+      },
+      {translateBuiltins: true, failFast: true});
+}
+
+function expectErroneousWithType(str: string) {
+  return chai.expect(() => translateSource(
+                         {
+                           'main.ts': str,
+                           'angular2/traceur-runtime.d.ts': traceurRuntimeDeclarations,
+                           'angular2/src/facade/lang.d.ts': langDeclarations,
+                         },
+                         {translateBuiltins: true, failFast: true}));
+}
+
+
+describe('collection façade', () => {
+  it('translates array operations to dartisms', () => {
+    expectWithTypes('var x: Array<number> = []; x.push(1);')
+        .to.equal(' List < num > x = [ ] ; x . add ( 1 ) ;');
+    expectWithTypes('var x: Array<number> = []; x.map((e) => e);')
+        .to.equal(' List < num > x = [ ] ; x . map ( ( e ) => e ) . toList ( ) ;');
+  });
+
+  it('translates map operations to dartisms', () => {
+    expectWithTypes('var x: Map<string, string> = new Map(); x.set("k", "v");')
+        .to.equal(' Map < String , String > x = new Map ( ) ; x [ "k" ] = "v" ;');
+    expectWithTypes('var x: Map<string, string> = new Map(); x.get("k");')
+        .to.equal(' Map < String , String > x = new Map ( ) ; x [ "k" ] ;');
+  });
+});
+
+describe('magic functions', () => {
+  it('translates CONST_EXPR(...) to const (...)', () => {
+    expectWithTypes('import {CONST_EXPR} from "angular2/src/facade/lang";\n' +
+                    'const x = CONST_EXPR([]);')
+        .to.equal(' const x = const [ ] ;');
+    expectWithTypes('import {CONST_EXPR} from "angular2/src/facade/lang";\n' +
+                    'const x = CONST_EXPR(new Person());')
+        .to.equal(' const x = const Person ( ) ;');
+    expectWithTypes('import {CONST_EXPR} from "angular2/src/facade/lang";\n' +
+                    'const x = CONST_EXPR({"one":1});')
+        .to.equal(' const x = const { "one" : 1 } ;');
+  });
+
+  it('translates FORWARD_REF(() => T) to T', () => {
+    expectWithTypes('import {FORWARD_REF} from "angular2/src/facade/lang";\n' +
+                    'var x = FORWARD_REF(() => SomeType);')
+        .to.equal(' var x = SomeType ;');
+    expectErroneousWithType('import {FORWARD_REF} from "angular2/src/facade/lang";\n' +
+                            'FORWARD_REF(1)')
+        .to.throw(/only arrow functions/);
+  });
+});
+
+describe('error detection', () => {
+  it('for untyped symbols matching special cased fns', () => {
+    expectErroneousWithType('FORWARD_REF(1)').to.throw(/Untyped property access to "FORWARD_REF"/);
+  });
+  it('for untyped symbols matching special cased methods',
+     () => { expectErroneousWithType('x.push(1)').to.throw(/Untyped property access to "push"/); });
+});

--- a/tsd.json
+++ b/tsd.json
@@ -22,6 +22,9 @@
     },
     "fs-extra/fs-extra.d.ts": {
       "commit": "d5f92f93bdb49f332fa662ff1d0cc8700f02e4dc"
+    },
+    "minimist/minimist.d.ts": {
+      "commit": "8b7cc13f6dbabd0a49de7ccba75c342160e600ad"
     }
   }
 }


### PR DESCRIPTION
- Bundles CONST_EXPR and FORWARD_REF into one place
- Special cases a bunch of Array methods, allowing more idiomatic TypeScript
  & Dart code
- Code structure should allow straight forward future additions.
