### PR TITLE
feat: test case for constructor comments.

### DIFF
--- a/test/main_test.ts
+++ b/test/main_test.ts
@@ -14,6 +14,10 @@ describe('main transpiler functionality', () => {
       expectTranslate('/* A */ a\n /* B */ b').to.equal('\n /* A */ a ;\n /* B */ b ;');
       expectTranslate('// A\na\n// B\nb').to.equal('\n // A\n a ;\n // B\n b ;');
     });
+    it('keeps ctor comments', () => {
+      expectTranslate('/** A */ class A {\n /** ctor */ constructor() {}}')
+          .to.equal('\n /** A */ class A {\n /** ctor */ A ( ) { } }');
+    });
   });
 
   describe('errors', () => {


### PR DESCRIPTION
These were always generated, but only if there is a line break before the
comment start, as otherwise TS considers the comment to belong to the pre-
ceding token.
