### PR TITLE
feat: explicitly fail for renamed imports & exports.

### DIFF
--- a/lib/module.ts
+++ b/lib/module.ts
@@ -58,7 +58,9 @@ class ImportExportTranspiler extends base.TranspilerStep {
       case ts.SyntaxKind.ImportSpecifier:
       case ts.SyntaxKind.ExportSpecifier:
         var spec = <ts.ImportOrExportSpecifier>node;
-        if (spec.propertyName) this.visitTypeName(spec.propertyName);
+        if (spec.propertyName) {
+          this.reportError(spec.propertyName, 'import/export renames are unsupported in Dart');
+        }
         this.visitTypeName(spec.name);
         break;
       case ts.SyntaxKind.ExportDeclaration:

--- a/test/module_test.ts
+++ b/test/module_test.ts
@@ -23,6 +23,10 @@ describe('imports', () => {
     expectTranslate('import {CONST, CONST_EXPR, IMPLEMENTS, ABSTRACT} from "x"').to.equal('');
     expectTranslate('import {x, IMPLEMENTS} from "./x"').to.equal(' import "x.dart" show x ;');
   });
+  it('fails for renamed imports', () => {
+    expectErroneousCode('import {Foo as Bar} from "baz";')
+        .to.throw(/import\/export renames are unsupported in Dart/);
+  });
 });
 
 describe('exports', () => {
@@ -37,6 +41,10 @@ describe('exports', () => {
      () => { expectTranslate('export * from "./X";').to.equal(' export "X.dart" ;'); });
   it('allows named export declarations', () => {
     expectTranslate('export {a, b} from "X";').to.equal(' export "package:X.dart" show a , b ;');
+  });
+  it('fails for renamed exports', () => {
+    expectErroneousCode('export {Foo as Bar} from "baz";')
+        .to.throw(/import\/export renames are unsupported in Dart/);
   });
   it('fails for exports without URLs', () => {
     expectErroneousCode('export {a as b};').to.throw('re-exports must have a module URL');


### PR DESCRIPTION
These are not supported by Dart.
