### PR TITLE
feat: ignore return types for arrow functions.

### DIFF
--- a/lib/declaration.ts
+++ b/lib/declaration.ts
@@ -223,7 +223,16 @@ class DeclarationTranspiler extends base.TranspilerStep {
   }
 
   private visitFunctionLike(fn: ts.FunctionLikeDeclaration, accessor?: string) {
-    if (fn.type) this.visit(fn.type);
+    if (fn.type) {
+      if (fn.kind === ts.SyntaxKind.ArrowFunction) {
+        // Type is silently dropped for arrow functions, not supported in Dart.
+        this.emit('/*');
+        this.visit(fn.type);
+        this.emit('*/');
+      } else {
+        this.visit(fn.type);
+      }
+    }
     if (accessor) this.emit(accessor);
     if (fn.name) this.visit(fn.name);
     // Dart does not even allow the parens of an empty param list on getter

--- a/test/function_test.ts
+++ b/test/function_test.ts
@@ -38,6 +38,7 @@ describe('functions', () => {
      () => { expectTranslate('var a = function() {}').to.equal(' var a = ( ) { } ;'); });
   it('translates fat arrow operator', () => {
     expectTranslate('var a = () => {}').to.equal(' var a = ( ) { } ;');
+    expectTranslate('var a = (): string => {}').to.equal(' var a = /* String */ ( ) { } ;');
     expectTranslate('var a = (p) => isBlank(p)').to.equal(' var a = ( p ) => isBlank ( p ) ;');
     expectTranslate('var a = (p = null) => isBlank(p)')
         .to.equal(' var a = ( [ p = null ] ) => isBlank ( p ) ;');


### PR DESCRIPTION
Dart does not support closures with return types.

Fixes #179.
