### PR TITLE
feat(types): disallow inline function types

### DIFF
--- a/lib/literal.ts
+++ b/lib/literal.ts
@@ -33,7 +33,7 @@ class LiteralTranspiler extends base.TranspilerBase {
         if (tmpl.templateSpans) this.visitEach(tmpl.templateSpans);
         break;
       case ts.SyntaxKind.TemplateHead:
-        this.emit(`'''${this.escapeTextForTemplateString(node)}`); //highlighting bug:'
+        this.emit(`'''${this.escapeTextForTemplateString(node)}`);  // highlighting bug:'
         break;
       case ts.SyntaxKind.TemplateTail:
         this.emitNoSpace(this.escapeTextForTemplateString(node));

--- a/lib/type.ts
+++ b/lib/type.ts
@@ -45,9 +45,8 @@ class TypeTranspiler extends base.TranspilerBase {
         this.emit('>');
         break;
       case ts.SyntaxKind.FunctionType:
-        this.emit('dynamic /*');
-        this.emit(node.getText());
-        this.emit('*/');
+        this.reportError(node, 'Inline function type declarations not supported. ' +
+                                   'Use function types instead (http://goo.gl/ROC5jN).');
         break;
       case ts.SyntaxKind.QualifiedName:
         var first = <ts.QualifiedName>node;

--- a/test/literal_test.ts
+++ b/test/literal_test.ts
@@ -4,7 +4,7 @@ import {expectTranslate, expectErroneousCode} from './test_support';
 describe('literals', () => {
   it('translates string literals', () => {
     expectTranslate(`'hello\\' "world'`).to.equal(` "hello' \\"world" ;`);
-      expectTranslate(`"hello\\" 'world"`).to.equal(` "hello\\" 'world" ;`);
+    expectTranslate(`"hello\\" 'world"`).to.equal(` "hello\\" 'world" ;`);
   });
 
   it('translates string templates', () => {

--- a/test/type_test.ts
+++ b/test/type_test.ts
@@ -1,5 +1,5 @@
 /// <reference path="../typings/mocha/mocha.d.ts"/>
-import {expectTranslate} from './test_support';
+import {expectTranslate, expectErroneousCode} from './test_support';
 
 describe('types', () => {
   it('supports qualified names',
@@ -25,9 +25,10 @@ describe('types', () => {
   });
   it('should support array types',
      () => { expectTranslate('var x: string[] = [];').to.equal(' List < String > x = [ ] ;'); });
-  it('should support function types (by ignoring them)', () => {
-    expectTranslate('var x: (a: string) => string;')
-        .to.equal(' dynamic /* (a: string) => string */ x ;');
+  it('should not support inline function types', () => {
+    expectErroneousCode('var x: (a: string) => string;')
+        .to.throw('Inline function type declarations not supported. ' +
+                  'Use function types instead (http://goo.gl/ROC5jN).');
   });
 });
 


### PR DESCRIPTION
This PR is a spin-off of https://github.com/angular/ts2dart/pull/220 (more discussion: https://github.com/angular/ts2dart/pull/220#discussion_r33064068)

Inline function types are not supported in Dart for local variables other than function parameters and allowing them in ts2dart gives developers a false impression that they can use it, while in fact dart2js simply erases them producing bad Dart code. Given the goal of the project is to produce idiomatic Dart, it is reasonable to push developers to use only those language constructs that ts2dart is able to translate cleanly, which in this case is named function types.
