### PR TITLE
feat: be stricter about empty imports/exports.

### DIFF
--- a/lib/module.ts
+++ b/lib/module.ts
@@ -52,7 +52,9 @@ export default class ModuleTranspiler extends base.TranspilerBase {
         this.visitList(used);
         break;
       case ts.SyntaxKind.NamedExports:
+        var exportElements = (<ts.NamedExports>node).elements;
         this.emit('show');
+        if (exportElements.length === 0) this.reportError(node, 'empty export list');
         this.visitList((<ts.NamedExports>node).elements);
         break;
       case ts.SyntaxKind.ImportSpecifier:
@@ -124,7 +126,11 @@ export default class ModuleTranspiler extends base.TranspilerBase {
   private isEmptyImport(n: ts.ImportDeclaration): boolean {
     var bindings = n.importClause.namedBindings;
     if (bindings.kind != ts.SyntaxKind.NamedImports) return false;
-    return (<ts.NamedImports>bindings).elements.every(ModuleTranspiler.isIgnoredImport);
+    var elements = (<ts.NamedImports>bindings).elements;
+    // An import list being empty *after* filtering is ok, but if it's empty in the code itself,
+    // it's nonsensical code, so probably a programming error.
+    if (elements.length === 0) this.reportError(n, 'empty import list');
+    return elements.every(ModuleTranspiler.isIgnoredImport);
   }
 
   private filterImports(ns: ts.ImportOrExportSpecifier[]) {

--- a/test/module_test.ts
+++ b/test/module_test.ts
@@ -28,6 +28,8 @@ describe('imports', () => {
     expectErroneousCode('import {Foo as Bar} from "baz";')
         .to.throw(/import\/export renames are unsupported in Dart/);
   });
+  it('fails for empty import specs',
+     () => { expectErroneousCode('import {} from "baz";').to.throw(/empty import list/); });
 });
 
 describe('exports', () => {
@@ -50,6 +52,8 @@ describe('exports', () => {
   it('fails for exports without URLs', () => {
     expectErroneousCode('export {a as b};').to.throw('re-exports must have a module URL');
   });
+  it('fails for empty export specs',
+     () => { expectErroneousCode('export {} from "baz";').to.throw(/empty export list/); });
 });
 
 describe('library name', () => {


### PR DESCRIPTION
`import/export {} from "";` is nonsensical code. The statement is valid
in TypeScript, but `ts2dart` should given an error, as this probably
indicates a mistake or superfluous code.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/ts2dart/229)

<!-- Reviewable:end -->
