### PR TITLE
feat(typing): namespace the translated type names.

### DIFF
--- a/lib/base.ts
+++ b/lib/base.ts
@@ -74,27 +74,6 @@ export class TranspilerBase {
     return this.transpiler.getRelativeFileName(fileName);
   }
 
-  private static TS_TO_DART_TYPENAMES: {[k: string]: string} = {
-    'Promise': 'Future',
-    'Observable': 'Stream',
-    'ObservableController': 'StreamController',
-    'Date': 'DateTime',
-    'StringMap': 'Map',
-    'Array': 'List',
-  };
-
-  visitTypeName(typeName: ts.EntityName) {
-    if (typeName.kind !== ts.SyntaxKind.Identifier) {
-      this.visit(typeName);
-      return;
-    }
-    var identifier = ident(typeName);
-    if (TranspilerBase.TS_TO_DART_TYPENAMES.hasOwnProperty(identifier)) {
-      identifier = TranspilerBase.TS_TO_DART_TYPENAMES[identifier];
-    }
-    this.emit(identifier);
-  }
-
   maybeVisitTypeArguments(n: {typeArguments?: ts.NodeArray<ts.TypeNode>}) {
     if (n.typeArguments) {
       this.emit('<');

--- a/lib/declaration.ts
+++ b/lib/declaration.ts
@@ -2,9 +2,10 @@
 import ts = require('typescript');
 import base = require('./base');
 import ts2dart = require('./main');
+import {FacadeConverter} from './facade_converter';
 
 class DeclarationTranspiler extends base.TranspilerBase {
-  constructor(tr: ts2dart.Transpiler) { super(tr); }
+  constructor(tr: ts2dart.Transpiler, private fc: FacadeConverter) { super(tr); }
 
   visitNode(node: ts.Node): boolean {
     switch (node.kind) {
@@ -61,7 +62,7 @@ class DeclarationTranspiler extends base.TranspilerBase {
           this.reportError(node, 'const enums are not supported');
         }
         this.emit('enum');
-        this.visitTypeName(decl.name);
+        this.fc.visitTypeName(decl.name);
         this.emit('{');
         // Enums can be empty in TS ...
         if (decl.members.length === 0) {
@@ -318,7 +319,7 @@ class DeclarationTranspiler extends base.TranspilerBase {
   private visitClassLike(keyword: string, decl: base.ClassLike) {
     this.visitDecorators(decl.decorators);
     this.emit(keyword);
-    this.visitTypeName(decl.name);
+    this.fc.visitTypeName(decl.name);
     if (decl.typeParameters) {
       this.emit('<');
       this.visitList(decl.typeParameters);
@@ -357,7 +358,7 @@ class DeclarationTranspiler extends base.TranspilerBase {
     // Generate a constructor to host the const modifier, if needed
     if (this.isConst(decl) && !decl.members.some((m) => m.kind == ts.SyntaxKind.Constructor)) {
       this.emit("const");
-      this.visitTypeName(decl.name);
+      this.fc.visitTypeName(decl.name);
       this.emit("();")
     }
     this.emit('}');

--- a/lib/expression.ts
+++ b/lib/expression.ts
@@ -24,7 +24,7 @@ class ExpressionTranspiler extends base.TranspilerBase {
           this.visit(binExpr.left);
           if (operatorKind === ts.SyntaxKind.InstanceOfKeyword) {
             this.emit('is');
-            this.visitTypeName(<ts.Identifier>binExpr.right);
+            this.fc.visitTypeName(<ts.Identifier>binExpr.right);
           } else {
             this.emit(ts.tokenToString(binExpr.operatorToken.kind));
             this.visit(binExpr.right);

--- a/lib/facade_converter.ts
+++ b/lib/facade_converter.ts
@@ -11,19 +11,22 @@ const FACADE_DEBUG = false;
 export class FacadeConverter extends base.TranspilerBase {
   private tc: ts.TypeChecker;
   private candidateProperties: {[propertyName: string]: boolean} = {};
+  private candidateTypes: {[typeName: string]: boolean} = {};
 
   constructor(transpiler: ts2dart.Transpiler) {
     super(transpiler);
     this.extractPropertyNames(this.callHandlers);
     this.extractPropertyNames(this.propertyHandlers);
+    this.extractPropertyNames(this.TS_TO_DART_TYPENAMES, this.candidateTypes);
   }
 
-  private extractPropertyNames(m: ts.Map<ts.Map<any>>) {
+  private extractPropertyNames(m: ts.Map<ts.Map<any>>,
+                               candidates: {[k: string]: boolean} = this.candidateProperties) {
     for (var fileName in m) {
       Object.keys(m[fileName])
           .filter((k) => m[fileName].hasOwnProperty(k))
           .map((propName) => propName.substring(propName.lastIndexOf('.') + 1))
-          .forEach((propName) => this.candidateProperties[propName] = true);
+          .forEach((propName) => candidates[propName] = true);
     }
   }
 
@@ -85,6 +88,30 @@ export class FacadeConverter extends base.TranspilerBase {
     return handler && !handler(pa);
   }
 
+  visitTypeName(typeName: ts.EntityName) {
+    if (typeName.kind !== ts.SyntaxKind.Identifier) {
+      this.visit(typeName);
+      return;
+    }
+    var ident = base.ident(typeName);
+    if (this.candidateTypes.hasOwnProperty(ident) && this.tc) {
+      var symbol = this.tc.getSymbolAtLocation(typeName);
+      if (!symbol) {
+        this.reportMissingType(typeName, ident);
+        return;
+      }
+      let fileAndName = this.getFileAndName(symbol);
+      if (fileAndName) {
+        var fileSubs = this.TS_TO_DART_TYPENAMES[fileAndName.fileName];
+        if (fileSubs && fileSubs.hasOwnProperty(fileAndName.qname)) {
+          this.emit(fileSubs[fileAndName.qname]);
+          return;
+        }
+      }
+    }
+    this.emit(ident);
+  }
+
   private getHandler<T>(symbol: ts.Symbol, m: ts.Map<ts.Map<T>>): T {
     var {fileName, qname} = this.getFileAndName(symbol);
     var fileSubs = m[fileName];
@@ -94,20 +121,26 @@ export class FacadeConverter extends base.TranspilerBase {
 
   private getFileAndName(symbol: ts.Symbol): {fileName: string, qname: string} {
     while (symbol.flags & ts.SymbolFlags.Alias) symbol = this.tc.getAliasedSymbol(symbol);
-    if (!symbol.valueDeclaration) return null;
+    let decl = symbol.valueDeclaration;
+    if (!decl) {
+      // In the case of a pure declaration with no assignment, there is no value declared.
+      // Just grab the first declaration, hoping it is declared once.
+      decl = symbol.declarations[0];
+    }
 
-    var fileName = symbol.valueDeclaration.getSourceFile().fileName;
+    var fileName = decl.getSourceFile().fileName;
     fileName = this.getRelativeFileName(fileName);
     fileName = fileName.replace(/(\.d)?\.ts$/, '');
 
     if (FACADE_DEBUG) console.log('fn:', fileName);
     var qname = this.tc.getFullyQualifiedName(symbol);
-    // Function and Variable Qualified Names include their file name. Might be a bug in TypeScript,
+    // Some Qualified Names include their file name. Might be a bug in TypeScript,
     // for the time being just special case.
-    if (symbol.flags & ts.SymbolFlags.Function || symbol.flags & ts.SymbolFlags.Variable) {
+    if (symbol.flags & ts.SymbolFlags.Function || symbol.flags & ts.SymbolFlags.Variable ||
+        symbol.flags & ts.SymbolFlags.Class) {
       qname = symbol.getName();
     }
-    if (FACADE_DEBUG) console.log('qn', qname);
+    if (FACADE_DEBUG) console.log('qn:', qname);
     return {fileName, qname};
   }
 
@@ -145,6 +178,34 @@ export class FacadeConverter extends base.TranspilerBase {
     if (args) this.visitList(args);
     this.emit(')');
   }
+
+  private stdlibTypeReplacements: ts.Map<string> = {
+    'Date': 'DateTime',
+    'Array': 'List',
+    'XMLHttpRequest': 'HttpRequest',
+
+    // Dart has two different incompatible DOM APIs
+    // https://github.com/angular/angular/issues/2770
+    'Node': 'dynamic',
+    'Text': 'dynamic',
+    'Element': 'dynamic',
+    'HTMLElement': 'dynamic',
+    'HTMLStyleElement': 'dynamic',
+    'HTMLInputElement': 'dynamic',
+    'HTMLDocument': 'dynamic',
+    'History': 'dynamic',
+    'Location': 'dynamic',
+  };
+
+  private TS_TO_DART_TYPENAMES: ts.Map<ts.Map<string>> = {
+    'lib': this.stdlibTypeReplacements,
+    'lib.es6': this.stdlibTypeReplacements,
+    'angular2/src/facade/async':
+        {'Promise': 'Future', 'Observable': 'Stream', 'ObservableController': 'StreamController'},
+    'angular2/src/facade/collection': {'StringMap': 'Map'},
+    'angular2/src/facade/lang': {'Date': 'DateTime'},
+    'angular2/globals': {'StringMap': 'Map'},
+  };
 
   private stdlibHandlers: ts.Map<CallHandler> = {
     'Array.push': (c: ts.CallExpression, context: ts.Expression) => {

--- a/lib/literal.ts
+++ b/lib/literal.ts
@@ -98,7 +98,7 @@ class LiteralTranspiler extends base.TranspilerBase {
         var regExp = (<ts.LiteralExpression>node).text;
         var slashIdx = regExp.lastIndexOf('/');
         var flags = regExp.substring(slashIdx + 1);
-        regExp = regExp.substring(1, slashIdx);  // cut off /.../ chars.
+        regExp = regExp.substring(1, slashIdx);            // cut off /.../ chars.
         regExp = regExp.replace(/'/g, '\' + "\'" + r\'');  // handle nested quotes by concatenation.
         this.emitNoSpace(regExp);
         this.emitNoSpace('\'');

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -65,12 +65,12 @@ export class Transpiler {
     this.fc = new FacadeConverter(this);
     this.transpilers = [
       new CallTranspiler(this, this.fc),  // Has to come before StatementTranspiler!
-      new DeclarationTranspiler(this),
+      new DeclarationTranspiler(this, this.fc),
       new ExpressionTranspiler(this, this.fc),
       new LiteralTranspiler(this, this.fc),
-      new ModuleTranspiler(this, options.generateLibraryName),
+      new ModuleTranspiler(this, this.fc, options.generateLibraryName),
       new StatementTranspiler(this),
-      new TypeTranspiler(this),
+      new TypeTranspiler(this, this.fc),
     ];
   }
 

--- a/lib/module.ts
+++ b/lib/module.ts
@@ -2,9 +2,13 @@
 import ts = require('typescript');
 import base = require('./base');
 import ts2dart = require('./main');
+import {FacadeConverter} from './facade_converter';
 
 export default class ModuleTranspiler extends base.TranspilerBase {
-  constructor(tr: ts2dart.Transpiler, private generateLibraryName: boolean) { super(tr); }
+  constructor(tr: ts2dart.Transpiler, private fc: FacadeConverter,
+              private generateLibraryName: boolean) {
+    super(tr);
+  }
 
   visitNode(node: ts.Node): boolean {
     switch (node.kind) {
@@ -33,7 +37,7 @@ export default class ModuleTranspiler extends base.TranspilerBase {
         break;
       case ts.SyntaxKind.ImportClause:
         var importClause = <ts.ImportClause>node;
-        if (importClause.name) this.visitTypeName(importClause.name);
+        if (importClause.name) this.fc.visitTypeName(importClause.name);
         if (importClause.namedBindings) {
           this.visit(importClause.namedBindings);
         }
@@ -41,7 +45,7 @@ export default class ModuleTranspiler extends base.TranspilerBase {
       case ts.SyntaxKind.NamespaceImport:
         var nsImport = <ts.NamespaceImport>node;
         this.emit('as');
-        this.visitTypeName(nsImport.name);
+        this.fc.visitTypeName(nsImport.name);
         break;
       case ts.SyntaxKind.NamedImports:
         this.emit('show');
@@ -61,7 +65,7 @@ export default class ModuleTranspiler extends base.TranspilerBase {
         if (spec.propertyName) {
           this.reportError(spec.propertyName, 'import/export renames are unsupported in Dart');
         }
-        this.visitTypeName(spec.name);
+        this.fc.visitTypeName(spec.name);
         break;
       case ts.SyntaxKind.ExportDeclaration:
         var exportDecl = <ts.ExportDeclaration>node;
@@ -79,7 +83,7 @@ export default class ModuleTranspiler extends base.TranspilerBase {
         this.emit('import');
         this.visit(importEqDecl.moduleReference);
         this.emit('as');
-        this.visitTypeName(importEqDecl.name);
+        this.fc.visitTypeName(importEqDecl.name);
         this.emit(';');
         break;
       case ts.SyntaxKind.ExternalModuleReference:

--- a/lib/type.ts
+++ b/lib/type.ts
@@ -2,9 +2,10 @@
 import ts = require('typescript');
 import base = require('./base');
 import ts2dart = require('./main');
+import {FacadeConverter} from './facade_converter';
 
 class TypeTranspiler extends base.TranspilerBase {
-  constructor(tr: ts2dart.Transpiler) { super(tr); }
+  constructor(tr: ts2dart.Transpiler, private fc: FacadeConverter) { super(tr); }
 
   visitNode(node: ts.Node): boolean {
     switch (node.kind) {
@@ -19,7 +20,7 @@ class TypeTranspiler extends base.TranspilerBase {
         break;
       case ts.SyntaxKind.TypeReference:
         var typeRef = <ts.TypeReferenceNode>node;
-        this.visitTypeName(typeRef.typeName);
+        this.fc.visitTypeName(typeRef.typeName);
         this.maybeVisitTypeArguments(typeRef);
         break;
       case ts.SyntaxKind.TypeAssertionExpression:

--- a/test/facade_converter_test.ts
+++ b/test/facade_converter_test.ts
@@ -25,9 +25,11 @@ function getSources(str: string): {[k: string]: string} {
     'angular2/traceur-runtime.d.ts': traceurRuntimeDeclarations,
     'angular2/src/di/forward_ref.d.ts': `
         export declare function forwardRef<T>(x: T): T;`,
+    'angular2/src/facade/async.d.ts': `
+        export declare var Promise = (<any>global).Promise;
+        export declare class Observable {};`,
     'angular2/src/facade/collection.d.ts': `
-        export declare var Map: typeof Map;
-    `,
+        export declare var Map: typeof Map;`,
     'angular2/src/facade/lang.d.ts': `
         interface List<T> extends Array<T> {}
         export declare function CONST_EXPR<T>(x: T): T;`,
@@ -35,7 +37,8 @@ function getSources(str: string): {[k: string]: string} {
         export class X {
           map(x: number): string { return String(x); }
           static get(m: any, k: string): number { return m[k]; }
-        }`,
+        }
+        export declare var Promise = (<any>global).Promise;`,
   };
   srcs['main.ts'] = str;
   return srcs;
@@ -55,6 +58,26 @@ function expectErroneousWithType(str: string) {
 }
 
 describe('type based translation', () => {
+  describe('Dart type substitution', () => {
+    it('finds registered substitutions', () => {
+      expectWithTypes(
+          'import {Promise, Observable} from "angular2/src/facade/async"; var p: Promise<Date>;')
+          .to.equal(
+              ' import "package:angular2/src/facade/async.dart" show Future , Stream ; Future < DateTime > p ;');
+      expectWithTypes('import {Promise} from "angular2/src/facade/async"; x instanceof Promise;')
+          .to.equal(' import "package:angular2/src/facade/async.dart" show Future ; x is Future ;');
+      expectWithTypes('var n: Node;').to.equal(' dynamic n ;');
+    });
+
+    it('allows undeclared types',
+       () => { expectWithTypes('var t: Thing;').to.equal(' Thing t ;'); });
+
+    it('does not substitute matching name from different file', () => {
+      expectWithTypes('import {Promise} from "other/file"; x instanceof Promise;')
+          .to.equal(' import "package:other/file.dart" show Promise ; x is Promise ;');
+    });
+  });
+
   describe('collection façade', () => {
     it('translates array operations to dartisms', () => {
       expectWithTypes('var x: Array<number> = []; x.push(1); x.pop();')

--- a/test/module_test.ts
+++ b/test/module_test.ts
@@ -2,6 +2,7 @@
 import chai = require('chai');
 import main = require('../lib/main');
 import ModuleTranspiler from '../lib/module';
+import {FacadeConverter} from '../lib/facade_converter';
 
 import {expectTranslate, expectErroneousCode, translateSources} from './test_support';
 
@@ -57,7 +58,7 @@ describe('library name', () => {
   var modTranspiler: ModuleTranspiler;
   beforeEach(() => {
     transpiler = new main.Transpiler({failFast: true, generateLibraryName: true, basePath: '/a'});
-    modTranspiler = new ModuleTranspiler(transpiler, true);
+    modTranspiler = new ModuleTranspiler(transpiler, new FacadeConverter(transpiler), true);
   });
   it('adds a library name', () => {
     var results = translateSources({'/a/b/c.ts': 'var x;'},

--- a/test/type_test.ts
+++ b/test/type_test.ts
@@ -6,13 +6,6 @@ describe('types', () => {
      () => { expectTranslate('var x: foo.Bar;').to.equal(' foo . Bar x ;'); });
   it('drops type literals',
      () => { expectTranslate('var x: {x: string, y: number};').to.equal(' dynamic x ;'); });
-  it('substitutes Dart-ism', () => {
-    expectTranslate('import {Promise} from "./somewhere"; var p: Promise<Date>;')
-        .to.equal(' import "somewhere.dart" show Future ; Future < DateTime > p ;');
-    expectTranslate('import Promise = require("./somewhere");')
-        .to.equal(' import "somewhere.dart" as Future ;');
-    expectTranslate('x instanceof Promise;').to.equal(' x is Future ;');
-  });
   it('allows typecasts',
      () => { expectTranslate('<MyType>ref').to.equal(' ( ref as MyType ) ;'); });
   it('does not mangle prototype names', () => {


### PR DESCRIPTION
This allows us to add more type translations for
DOM API without worry about colliding with other
unrelated types.

This required a bit of refactoring since the
TypeChecker is not generally available to the
transpilers.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/ts2dart/232)

<!-- Reviewable:end -->
