### PR TITLE
feat: support @CONST properties.

### DIFF
--- a/lib/declaration.ts
+++ b/lib/declaration.ts
@@ -299,13 +299,19 @@ class DeclarationTranspiler extends base.TranspilerBase {
                         isParameter: boolean = false) {
     if (!isParameter) this.visitDeclarationMetadata(decl);
     var containingClass = <base.ClassLike>(isParameter ? decl.parent.parent : decl.parent);
-    var hasConstCtor = this.isConst(containingClass);
-    if (hasConstCtor) {
-      this.emit('final');
+    var isConstField = this.hasAnnotation(decl.decorators, 'CONST');
+    if (isConstField) {
+      // const implies final
+      this.emit('const');
+    } else {
+      var hasConstCtor = this.isConst(containingClass);
+      if (hasConstCtor) {
+        this.emit('final');
+      }
     }
     if (decl.type) {
       this.visit(decl.type);
-    } else if (!hasConstCtor) {
+    } else if (!isConstField && !hasConstCtor) {
       this.emit('var');
     }
     this.visit(decl.name);

--- a/test/decorator_test.ts
+++ b/test/decorator_test.ts
@@ -28,6 +28,8 @@ describe('decorators', () => {
         .to.equal(' class X {' +
                   ' final num x ; final y ;' +
                   ' const X ( ) : x = 1 , y = 2 , super ( 3 ) ; }');
+
+    // @CONST constructors.
     expectTranslate('@CONST class X { constructor() {} }').to.equal(' class X { const X ( ) ; }');
     // For backwards-compatibility for traceur inputs (not valid TS input)
     expectTranslate('class X { @CONST constructor() {} }').to.equal(' class X { const X ( ) ; }');
@@ -41,6 +43,10 @@ describe('decorators', () => {
         .to.throw('assignments in const constructors must assign into this.');
     expectErroneousCode('class X { @CONST constructor() { thax = 1; } }')
         .to.throw('assignments in const constructors must assign into this.');
+
+    // @CONST properties.
+    expectTranslate('class Foo { @CONST() static foo = 1; }')
+        .to.equal(' class Foo { static const foo = 1 ; }');
   });
   it('special cases @ABSTRACT',
      () => { expectTranslate('@ABSTRACT class X {}').to.equal(' abstract class X { }'); });


### PR DESCRIPTION
Translates `class X { @CONST static y = 1; }` to
`class X { static const y = 1 }`.

Fixes #236.
