### PR TITLE
fix(ts2dart): emit members for `protected` property parameters

### DIFF
--- a/lib/declaration.ts
+++ b/lib/declaration.ts
@@ -153,7 +153,8 @@ class DeclarationTranspiler extends base.TranspilerBase {
         // Property parameters will have an explicit property declaration, so we just
         // need the dart assignment shorthand to reference the property.
         if (this.hasFlag(paramDecl.modifiers, ts.NodeFlags.Public) ||
-            this.hasFlag(paramDecl.modifiers, ts.NodeFlags.Private)) {
+            this.hasFlag(paramDecl.modifiers, ts.NodeFlags.Private) ||
+            this.hasFlag(paramDecl.modifiers, ts.NodeFlags.Protected)) {
           this.emit('this .');
           this.visit(paramDecl.name);
           if (paramDecl.initializer) {
@@ -351,7 +352,8 @@ class DeclarationTranspiler extends base.TranspilerBase {
     // Synthesize explicit properties for ctor with 'property parameters'
     let synthesizePropertyParam = (param: ts.ParameterDeclaration) => {
       if (this.hasFlag(param.modifiers, ts.NodeFlags.Public) ||
-          this.hasFlag(param.modifiers, ts.NodeFlags.Private)) {
+          this.hasFlag(param.modifiers, ts.NodeFlags.Private) ||
+          this.hasFlag(param.modifiers, ts.NodeFlags.Protected)) {
         // TODO: we should enforce the underscore prefix on privates
         this.visitProperty(param, true);
       }

--- a/test/declaration_test.ts
+++ b/test/declaration_test.ts
@@ -103,11 +103,13 @@ describe('classes', () => {
     });
     it('supports parameter properties', () => {
       expectTranslate(
-          'class X { c: number; constructor(private bar: B, public foo: string = "hello") {} }')
+          'class X { c: number; constructor(private bar: B, public foo: string = "hello", protected goggles: boolean = true) {} }')
           .to.equal(
-              ' class X { B bar ; String foo ; num c ; X ( this . bar , [ this . foo = \"hello\" ] ) { } }');
-      expectTranslate('@CONST class X { constructor(public foo: string, b: number) {} }')
-          .to.equal(' class X { final String foo ; const X ( this . foo , num b ) ; }');
+              ' class X { B bar ; String foo ; bool goggles ; num c ; X ( this . bar , [ this . foo = \"hello\" , this . goggles = true ] ) { } }');
+      expectTranslate(
+          '@CONST class X { constructor(public foo: string, b: number, protected marbles: boolean = true) {} }')
+          .to.equal(
+              ' class X { final String foo ; final bool marbles ; const X ( this . foo , num b , [ this . marbles = true ] ) ; }');
     });
   });
 });


### PR DESCRIPTION
I know it's not very meaningful in dart, but it's useful for TypeScript.

When mixed with dart's module-private semantics, it could work okay for
both.
