### PR TITLE
fix(ts options): turn on experimentalDecorators flag by default.

### DIFF
--- a/lib/main.ts
+++ b/lib/main.ts
@@ -45,6 +45,7 @@ export interface TranspilerOptions {
 
 export const COMPILER_OPTIONS: ts.CompilerOptions = {
   allowNonTsExtensions: true,
+  experimentalDecorators: true,
   module: ts.ModuleKind.CommonJS,
   target: ts.ScriptTarget.ES5,
 };


### PR DESCRIPTION
Typescript 1.5.3 release candidate throw errors on decorator usage
without this flag, which makes angular2 transpilation really noisy.
