### PR TITLE
feat: use container based Travis builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: dart # NodeJS is available everywhere
+sudo: false
 node_js:
   - "stable"
 before_script:


### PR DESCRIPTION
This appears to reduce build start times substantially (seconds, not minutes!).
