### PR TITLE
feat: adjust to new promise symbol location.

### DIFF
--- a/lib/facade_converter.ts
+++ b/lib/facade_converter.ts
@@ -225,8 +225,9 @@ export class FacadeConverter extends base.TranspilerBase {
   private TS_TO_DART_TYPENAMES: ts.Map<ts.Map<string>> = {
     'lib': this.stdlibTypeReplacements,
     'lib.es6': this.stdlibTypeReplacements,
+    'angular2/typings/es6-promise/es6-promise': {'Promise': 'Future'},
     'angular2/src/facade/async':
-        {'Promise': 'Future', 'Observable': 'Stream', 'ObservableController': 'StreamController'},
+        {'Observable': 'Stream', 'ObservableController': 'StreamController'},
     'angular2/src/facade/collection': {'StringMap': 'Map'},
     'angular2/src/facade/lang': {'Date': 'DateTime'},
     'angular2/globals': {'StringMap': 'Map'},

--- a/test/facade_converter_test.ts
+++ b/test/facade_converter_test.ts
@@ -25,8 +25,10 @@ function getSources(str: string): {[k: string]: string} {
     'angular2/traceur-runtime.d.ts': traceurRuntimeDeclarations,
     'angular2/src/di/forward_ref.d.ts': `
         export declare function forwardRef<T>(x: T): T;`,
+    'angular2/typings/es6-promise/es6-promise.d.ts': `
+        declare class Promise<R> {}`,
     'angular2/src/facade/async.d.ts': `
-        export declare var Promise = (<any>global).Promise;
+        export {Promise};
         export declare class Observable {};`,
     'angular2/src/facade/collection.d.ts': `
         export declare var Map: typeof Map;`,


### PR DESCRIPTION
Angular now re-exports Promise from the es6-promise.d.ts definition file. This
means ts2dart has to adjust the location its special casing.
