### PR TITLE
feat(Facade): detect when Array.forEach callback has more than 1 arg

### DIFF
--- a/lib/facade_converter.ts
+++ b/lib/facade_converter.ts
@@ -283,6 +283,31 @@ export class FacadeConverter extends base.TranspilerBase {
         this.emit(')');
       });
     },
+    'Array.forEach': (c: ts.CallExpression, context: ts.Expression) => {
+      let cb: any;
+      let params: any[];
+
+      switch (c.arguments[0].kind) {
+        case ts.SyntaxKind.FunctionExpression:
+          cb = <ts.FunctionExpression>(c.arguments[0]);
+          params = cb.parameters;
+          if (params.length != 1) {
+            this.reportError(c, 'Array.forEach callback requires exactly one argument');
+          }
+          break;
+
+        case ts.SyntaxKind.ArrowFunction:
+          cb = <ts.ArrowFunction>(c.arguments[0]);
+          params = cb.parameters;
+          if (params.length != 1) {
+            this.reportError(c, 'Array.forEach callback requires exactly one argument');
+          }
+          break;
+      }
+
+      this.visit(context);
+      this.emitMethodCall('forEach', c.arguments);
+    },
     'ArrayConstructor.isArray': (c: ts.CallExpression, context: ts.Expression) => {
       this.emit('( (');
       this.visitList(c.arguments);  // Should only be 1.
@@ -355,7 +380,7 @@ export class FacadeConverter extends base.TranspilerBase {
       },
       'Map.forEach': (c: ts.CallExpression, context: ts.Expression) => {
         let cb: any;
-        let params: any;
+        let params: any[];
 
         switch (c.arguments[0].kind) {
           case ts.SyntaxKind.FunctionExpression:

--- a/test/facade_converter_test.ts
+++ b/test/facade_converter_test.ts
@@ -102,6 +102,8 @@ describe('type based translation', () => {
           .to.equal(' List < num > x = [ ] ; List < num > y = ListWrapper.slice ( x , 0 ) ;');
       expectWithTypes('var x: Array<number> = []; var y: Array<number> = x.splice(0,1);')
           .to.equal(' List < num > x = [ ] ; List < num > y = ListWrapper.splice ( x , 0 , 1 ) ;');
+      expectWithTypes('var x: Array<number> = []; x.forEach(item => log(item));')
+          .to.equal(' List < num > x = [ ] ; x . forEach ( ( item ) => log ( item ) ) ;');
     });
 
     it('translates map operations to dartisms', () => {
@@ -194,6 +196,11 @@ describe('type based translation', () => {
       it('.concat() should report an error if any arg is not an Array', () => {
         expectErroneousWithType('var x: Array<number> = []; x.concat(1);')
             .to.throw('Array.concat only takes Array arguments');
+      });
+
+      it('.forEach() should report an error when the callback doesn\'t have 1 arg', () => {
+        expectErroneousWithType('var x: Array<number> = []; x.forEach((item, idx, arr) => null);')
+            .to.throw('Array.forEach callback requires exactly one argument');
       });
     });
 


### PR DESCRIPTION
Whenever a function (function expression or arrow function) is passed to `Array.forEach()`, makes sure the function takes exactly one parameter (as expected by Dart - JS could have up to 3 params).

Note that no check is performed when the callback is an identifier (`a.forEach(myFn)`).

Supersedes #213
