### PR TITLE
chore: change tracer-runtime and globals paths

### DIFF
--- a/lib/facade_converter.ts
+++ b/lib/facade_converter.ts
@@ -249,7 +249,7 @@ export class FacadeConverter extends base.TranspilerBase {
         {'Observable': 'Stream', 'ObservableController': 'StreamController'},
     'angular2/src/core/facade/collection': {'StringMap': 'Map'},
     'angular2/src/core/facade/lang': {'Date': 'DateTime'},
-    'angular2/globals': {'StringMap': 'Map'},
+    'angular2/manual_typings/globals': {'StringMap': 'Map'},
   };
 
   private stdlibHandlers: ts.Map<CallHandler> = {
@@ -339,7 +339,7 @@ export class FacadeConverter extends base.TranspilerBase {
         return false;
       },
     },
-    'angular2/traceur-runtime': {
+    'angular2/manual_typings/traceur-runtime': {
       'Map.set': (c: ts.CallExpression, context: ts.Expression) => {
         this.visit(context);
         this.emit('[');
@@ -444,7 +444,7 @@ export class FacadeConverter extends base.TranspilerBase {
   };
 
   private propertyHandlers: ts.Map<ts.Map<PropertyHandler>> = {
-    'angular2/traceur-runtime': {
+    'angular2/manual_typings/traceur-runtime': {
       'Map.size': (p: ts.PropertyAccessExpression) => {
         this.visit(p.expression);
         this.emit('.');

--- a/test/facade_converter_test.ts
+++ b/test/facade_converter_test.ts
@@ -23,7 +23,7 @@ var traceurRuntimeDeclarations = `
 
 function getSources(str: string): {[k: string]: string} {
   var srcs: {[k: string]: string} = {
-    'angular2/traceur-runtime.d.ts': traceurRuntimeDeclarations,
+    'angular2/manual_typings/traceur-runtime.d.ts': traceurRuntimeDeclarations,
     'angular2/src/core/di/forward_ref.d.ts': `
         export declare function forwardRef<T>(x: T): T;`,
     'angular2/typings/es6-promise/es6-promise.d.ts': `


### PR DESCRIPTION
I've moved these in a branch on angular/angular that I'm planning to PR soon. I'll publish ts2dart and add a commit to my PR updating the dependency.
