### PR TITLE
chore(typings): list the external API definition in package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.7.5",
   "description": "Transpile TypeScript code to Dart",
   "main": "build/lib/main.js",
+  "typings": "build/definitions/main.d.ts",
   "directories": {
     "test": "test"
   },


### PR DESCRIPTION
This is supported by new Typescript ModuleResolutionKind=node as described in the proposal here:
https://github.com/Microsoft/TypeScript/issues/2338
