### PR TITLE
chore: clean up gulpfile, use tsconfig.json.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -14,19 +14,6 @@ var ts = require('gulp-typescript');
 var typescript = require('typescript');
 var which = require('which');
 
-var TSC_OPTIONS = {
-  module: "commonjs",
-  // allow pulling in files from node_modules until TS 1.5 is in tsd / DefinitelyTyped (the
-  // alternative is to include node_modules paths in the src arrays below for compilation)
-  noExternalResolve: false,
-  noImplicitAny: true,
-  declarationFiles: true,
-  noEmitOnError: true,
-  // Specify the TypeScript version we're using.
-  typescript: typescript,
-};
-var tsProject = ts.createProject(TSC_OPTIONS);
-
 gulp.task('test.check-format', function() {
   return gulp.src(['*.js', 'lib/**/*.ts', 'test/**/*.ts'])
       .pipe(formatter.checkFormat('file', clangFormat))
@@ -43,6 +30,9 @@ var onError = function(err) {
     process.exit(1);
   }
 };
+
+var tsProject =
+    ts.createProject('tsconfig.json', {noEmit: false, declaration: true, typescript: typescript});
 
 gulp.task('compile', function() {
   hasError = false;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,15 @@
 {
   "compilerOptions": {
     "module": "commonjs",
+    "moduleResolution": "node",
+    "noEmit": true,
+    "noEmitOnError": true,
     "noImplicitAny": true,
-    "noEmit": true
-  }
+    "noImplicitAny": true
+  },
+  "exclude": [
+    "node_modules",
+    "build",
+    "test/e2e"
+  ]
 }


### PR DESCRIPTION
- Always use tsconfig.json as the one authoritative source for
  compilation.
- Specify noEmit so that IDEs don't generate files on disk.
- Override tsconfig.json options as needed:
  - noEmit: false to emit files
  - declaration: true to generate .d.ts files
  - typescript to specify the TS version used
