### PR TITLE
Fixes to t2dart to make it run within Google

### DIFF
--- a/lib/mkdirp.ts
+++ b/lib/mkdirp.ts
@@ -1,14 +1,17 @@
 import * as fs from 'fs';
 import * as path from 'path';
 
-
 export default function mkdirP(p: string) {
-  let absPath = process.cwd();
+  // Convert input path to absolute and then relative so that we always have relative path in the
+  // end. This can be made simpler when path.isAbsolute is available in node v0.12.
+  p = path.resolve(p);
+  p = path.relative('', p);
 
+  var pathToCreate = '';
   p.split(path.sep).forEach(dirName => {
-    absPath = path.join(absPath, dirName);
-    if (!fs.existsSync(absPath)) {
-      fs.mkdir(absPath);
+    pathToCreate = path.join(pathToCreate, dirName);
+    if (!fs.existsSync(pathToCreate)) {
+      fs.mkdirSync(pathToCreate);
     }
   })
 }

--- a/test/main_test.ts
+++ b/test/main_test.ts
@@ -4,6 +4,7 @@
 import SourceMap = require('source-map');
 import chai = require('chai');
 import main = require('../lib/main');
+import path = require('path');
 import ts = require('typescript');
 
 import {expectTranslate, expectErroneousCode, translateSources} from './test_support';
@@ -44,10 +45,11 @@ describe('main transpiler functionality', () => {
 
   describe('output paths', () => {
     it('writes within the path', () => {
-      var transpiler = new main.Transpiler({basePath: '/a'});
-      chai.expect(transpiler.getOutputPath('/a/b/c.js', '/x')).to.equal('/x/b/c.dart');
-      chai.expect(transpiler.getOutputPath('b/c.js', '/x')).to.equal('/x/b/c.dart');
-      chai.expect(transpiler.getOutputPath('b/c.js', 'x')).to.equal('x/b/c.dart');
+      var transpiler = new main.Transpiler({basePath: 'a'});
+      chai.expect(transpiler.getOutputPath(path.resolve('a/b/c.js'), '/x')).to.equal('/x/b/c.dart');
+      chai.expect(transpiler.getOutputPath(path.resolve('a/b/c.js'), 'x')).to.equal('x/b/c.dart');
+      chai.expect(transpiler.getOutputPath('a/b/c.js', '/x')).to.equal('/x/b/c.dart');
+      chai.expect(transpiler.getOutputPath('a/b/c.js', 'x')).to.equal('x/b/c.dart');
       chai.expect(() => transpiler.getOutputPath('/outside/b/c.js', '/x'))
           .to.throw(/must be located under base/);
     });

--- a/test/module_test.ts
+++ b/test/module_test.ts
@@ -58,29 +58,32 @@ describe('exports', () => {
 });
 
 describe('library name', () => {
+  var cwd: string;
   var transpiler: main.Transpiler;
   var modTranspiler: ModuleTranspiler;
   beforeEach(() => {
-    transpiler = new main.Transpiler({failFast: true, generateLibraryName: true, basePath: '/a'});
+    cwd = process.cwd();
+    transpiler =
+        new main.Transpiler({failFast: true, generateLibraryName: true, basePath: cwd + '/a'});
     modTranspiler = new ModuleTranspiler(transpiler, new FacadeConverter(transpiler), true);
   });
   it('adds a library name', () => {
     var results = translateSources(
-        {'/a/b/c.ts': 'var x;'}, {failFast: true, generateLibraryName: true, basePath: '/a'});
-    chai.expect(results['/a/b/c.ts']).to.equal(' library b.c ; var x ;');
+        {'a/b/c.ts': 'var x;'}, {failFast: true, generateLibraryName: true, basePath: cwd + '/a'});
+    chai.expect(results['a/b/c.ts']).to.equal(' library b.c ; var x ;');
   });
-  it('leaves relative paths alone',
-     () => { chai.expect(modTranspiler.getLibraryName('a/b')).to.equal('a.b'); });
+  it('handles relative paths',
+     () => { chai.expect(modTranspiler.getLibraryName('a/b')).to.equal('b'); });
   it('handles reserved words', () => {
-    chai.expect(modTranspiler.getLibraryName('/a/for/in/do/x')).to.equal('_for._in._do.x');
+    chai.expect(modTranspiler.getLibraryName(cwd + '/a/for/in/do/x')).to.equal('_for._in._do.x');
   });
   it('handles built-in and limited keywords', () => {
-    chai.expect(modTranspiler.getLibraryName('/a/as/if/sync/x')).to.equal('as._if.sync.x');
+    chai.expect(modTranspiler.getLibraryName(cwd + '/a/as/if/sync/x')).to.equal('as._if.sync.x');
   });
   it('handles file extensions', () => {
-    chai.expect(modTranspiler.getLibraryName('a/x.ts')).to.equal('a.x');
-    chai.expect(modTranspiler.getLibraryName('a/x.js')).to.equal('a.x');
+    chai.expect(modTranspiler.getLibraryName('a/x.ts')).to.equal('x');
+    chai.expect(modTranspiler.getLibraryName('a/x.js')).to.equal('x');
   });
   it('handles non word characters',
-     () => { chai.expect(modTranspiler.getLibraryName('a/%x.ts')).to.equal('a._x'); });
+     () => { chai.expect(modTranspiler.getLibraryName('a/%x.ts')).to.equal('_x'); });
 });


### PR DESCRIPTION
Upstreaming local Google changes to public github repository.
- ts2dart should now handle relative path names as input and basePath. Fixed tests accordingly.
- Removed inlined fs-extra code and switched to using our own mkdirP implementation.
- Also fixed some bugs with mkdirP.
