### PR TITLE
feat(module): Add an option to specify a library name prefix

### DIFF
--- a/lib/main.ts
+++ b/lib/main.ts
@@ -23,6 +23,11 @@ export interface TranspilerOptions {
   failFast?: boolean;
   /** Whether to generate 'library a.b.c;' names from relative file paths. */
   generateLibraryName?: boolean;
+
+  /** A prefix to be prepended to all library names. This is useful when specifying the base path
+   * generates the correct destination file name but the generated library name is not sufficient.
+   */
+  libraryNamePrefix?: string;
   /** Whether to generate source maps. */
   generateSourceMap?: boolean;
   /**
@@ -71,7 +76,7 @@ export class Transpiler {
       new DeclarationTranspiler(this, this.fc, options.enforceUnderscoreConventions),
       new ExpressionTranspiler(this, this.fc),
       new LiteralTranspiler(this, this.fc),
-      new ModuleTranspiler(this, this.fc, options.generateLibraryName),
+      new ModuleTranspiler(this, this.fc, options.generateLibraryName, options.libraryNamePrefix),
       new StatementTranspiler(this),
       new TypeTranspiler(this, this.fc),
     ];

--- a/lib/module.ts
+++ b/lib/module.ts
@@ -5,7 +5,8 @@ import {FacadeConverter} from './facade_converter';
 
 export default class ModuleTranspiler extends base.TranspilerBase {
   constructor(
-      tr: ts2dart.Transpiler, private fc: FacadeConverter, private generateLibraryName: boolean) {
+      tr: ts2dart.Transpiler, private fc: FacadeConverter, private generateLibraryName: boolean,
+      private libraryNamePrefix?: string) {
     super(tr);
   }
 
@@ -159,6 +160,9 @@ export default class ModuleTranspiler extends base.TranspilerBase {
   getLibraryName(nameForTest?: string) {
     var fileName = this.getRelativeFileName(nameForTest);
     var parts = fileName.split('/');
+    if (this.libraryNamePrefix) {
+      parts = this.libraryNamePrefix.split('.').concat(parts);
+    }
     return parts.filter((p) => p.length > 0)
         .map((p) => p.replace(/[^\w.]/g, '_'))
         .map((p) => p.replace(/\.[jt]s$/g, ''))

--- a/test/module_test.ts
+++ b/test/module_test.ts
@@ -62,23 +62,33 @@ describe('library name', () => {
   var transpiler: main.Transpiler;
   var modTranspiler: ModuleTranspiler;
   beforeEach(() => {
-    cwd = process.cwd();
-    transpiler =
-        new main.Transpiler({failFast: true, generateLibraryName: true, basePath: cwd + '/a'});
+    transpiler = new main.Transpiler({failFast: true, generateLibraryName: true, basePath: 'a'});
     modTranspiler = new ModuleTranspiler(transpiler, new FacadeConverter(transpiler), true);
   });
   it('adds a library name', () => {
     var results = translateSources(
-        {'a/b/c.ts': 'var x;'}, {failFast: true, generateLibraryName: true, basePath: cwd + '/a'});
+        {'a/b/c.ts': 'var x;'}, {failFast: true, generateLibraryName: true, basePath: 'a'});
     chai.expect(results['a/b/c.ts']).to.equal(' library b.c ; var x ;');
+  });
+  it('adds a library name with simple prefix', () => {
+    var results = translateSources(
+        {'a/b/c.ts': 'var x;'},
+        {failFast: true, generateLibraryName: true, libraryNamePrefix: 'i', basePath: 'a'});
+    chai.expect(results['a/b/c.ts']).to.equal(' library i.b.c ; var x ;');
+  });
+  it('adds a library name with multi-part prefix', () => {
+    var results = translateSources(
+        {'a/b/c.ts': 'var x;'},
+        {failFast: true, generateLibraryName: true, libraryNamePrefix: 'i.j', basePath: 'a'});
+    chai.expect(results['a/b/c.ts']).to.equal(' library i.j.b.c ; var x ;');
   });
   it('handles relative paths',
      () => { chai.expect(modTranspiler.getLibraryName('a/b')).to.equal('b'); });
   it('handles reserved words', () => {
-    chai.expect(modTranspiler.getLibraryName(cwd + '/a/for/in/do/x')).to.equal('_for._in._do.x');
+    chai.expect(modTranspiler.getLibraryName('a/for/in/do/x')).to.equal('_for._in._do.x');
   });
   it('handles built-in and limited keywords', () => {
-    chai.expect(modTranspiler.getLibraryName(cwd + '/a/as/if/sync/x')).to.equal('as._if.sync.x');
+    chai.expect(modTranspiler.getLibraryName('a/as/if/sync/x')).to.equal('as._if.sync.x');
   });
   it('handles file extensions', () => {
     chai.expect(modTranspiler.getLibraryName('a/x.ts')).to.equal('x');


### PR DESCRIPTION
Add a new option libraryNamePrefix which will add a prefix to the generated library names.

This is useful when the library name generated by basePath is removing some part of the library name that's needed.

Ex. For Angular 2 - basePath=modules/angular2, libraryNamePrefix=angular2 would still generate the right library names with "angular2.xxx.xxx"
