### PR TITLE
feat: support loading rxjs from node_modules.

### DIFF
--- a/test/facade_converter_test.ts
+++ b/test/facade_converter_test.ts
@@ -1,5 +1,11 @@
 /// <reference path="../typings/mocha/mocha.d.ts"/>
-import {parseFiles, expectTranslate, expectErroneousCode, translateSource} from './test_support';
+import {
+  parseFiles,
+  expectTranslate,
+  FAKE_MAIN,
+  expectErroneousCode,
+  translateSource
+} from './test_support';
 import chai = require('chai');
 
 var es6RuntimeDeclarations = `
@@ -31,9 +37,11 @@ function getSources(str: string): {[k: string]: string} {
         export declare function forwardRef<T>(x: T): T;`,
     'angular2/typings/es6-promise/es6-promise.d.ts': `
         export declare class Promise<R> {}`,
+    'node_modules/rxjs/Observable.d.ts': `
+        export declare class Observable {}`,
     'angular2/src/facade/async.ts': `
-        export {Promise} from "angular2/typings/es6-promise/es6-promise";
-        export declare class Observable {};`,
+        export {Promise} from 'angular2/typings/es6-promise/es6-promise';
+        export {Observable} from 'rxjs/Observable';`,
     'angular2/src/facade/collection.ts': `
         export declare var Map;`,
     'angular2/src/facade/lang.d.ts': `
@@ -48,7 +56,7 @@ function getSources(str: string): {[k: string]: string} {
         var global: any;
         export var Promise = global.Promise;`,
   };
-  srcs['main.ts'] = str;
+  srcs[FAKE_MAIN] = str;
   return srcs;
 }
 

--- a/test/test_support.ts
+++ b/test/test_support.ts
@@ -45,14 +45,15 @@ export function parseFiles(nameToContent: StringMap): ts.Program {
       return undefined;
     },
     writeFile: function(name, text, writeByteOrderMark) { result = text; },
-    fileExists: (filename) => !!nameToContent[filename],
-    readFile: (filename) => nameToContent[filename],
+    fileExists: (sourceName) => { return !!nameToContent[sourceName]; },
+    readFile: (filename): string => { throw new Error('unexpected call to readFile'); },
     getDefaultLibFileName: () => defaultLibName,
     useCaseSensitiveFileNames: () => false,
-    getCanonicalFileName: (filename) => filename,
+    getCanonicalFileName: (filename) => '../' + filename,
     getCurrentDirectory: () => '',
-    getNewLine: () => '\n'
+    getNewLine: () => '\n',
   };
+  compilerHost.resolveModuleNames = main.getModuleResolver(compilerHost);
   // Create a program from inputs
   var entryPoints = Object.keys(nameToContent);
   var program: ts.Program = ts.createProgram(entryPoints, compilerOptions, compilerHost);
@@ -64,13 +65,15 @@ export function parseFiles(nameToContent: StringMap): ts.Program {
   return program;
 }
 
+export const FAKE_MAIN = 'angular2/some/main.ts';
+
 export function translateSources(contents: Input, options: main.TranspilerOptions = {}): StringMap {
   // Default to quick stack traces.
   if (!options.hasOwnProperty('failFast')) options.failFast = true;
   var namesToContent: StringMap;
   if (typeof contents === 'string') {
     namesToContent = {};
-    namesToContent['main.ts'] = contents;
+    namesToContent[FAKE_MAIN] = contents;
   } else {
     namesToContent = contents;
   }
@@ -84,5 +87,5 @@ export function translateSources(contents: Input, options: main.TranspilerOption
 export function translateSource(contents: Input, options: main.TranspilerOptions = {}): string {
   var results = translateSources(contents, options);
   // Return the main outcome, from 'main.ts'.
-  return results['main.ts'];
+  return results[FAKE_MAIN];
 }


### PR DESCRIPTION
Angular no longer declares Observable itself, but rather re-exports from
rxjs/Observable. This change adjusts to the new location, and also
supports loading from node_modules.
