### PR TITLE
chore(facade): allow es6 methods to be defined in another location.

### DIFF
--- a/lib/facade_converter.ts
+++ b/lib/facade_converter.ts
@@ -449,6 +449,7 @@ export class FacadeConverter extends base.TranspilerBase {
     'lib.es6': this.stdlibHandlers,
     'angular2/typings/es6-shim/es6-shim': this.es6Collections,
     'angular2/typings/es6-collections/es6-collections': this.es6Collections,
+    'angular2/manual_typings/globals': this.es6Collections,
     'angular2/src/facade/collection': {
       'Map': (c: ts.CallExpression, context: ts.Expression): boolean => {
         // The actual Map constructor is special cased for const calls.


### PR DESCRIPTION
Context: https://github.com/angular/angular/issues/5242
We don't want usage of arbitrary es6 APIs to type-check.

I'll start moving over non-es6-collections methods first, but need a ts2dart release before the angular changes.
