### PR TITLE
fix(test): Move e2e tests to Dart 'test' from deprecated 'unittest' package

### DIFF
--- a/test/e2e/helloworld.ts
+++ b/test/e2e/helloworld.ts
@@ -1,5 +1,5 @@
-/// <reference path="./unittest.d.ts"/>
-import t = require("unittest/unittest");
+/// <reference path="./test.d.ts"/>
+import t = require("test/test");
 import {MyClass, MySubclass, SomeArray} from './lib';
 
 

--- a/test/e2e/pubspec.yaml
+++ b/test/e2e/pubspec.yaml
@@ -2,4 +2,4 @@ name: e2e
 description: Transpiled end-to-end tests for ts2dart.  
 
 dependencies:
-  unittest: any
+  test: 0.12.8

--- a/test/e2e/test.d.ts
+++ b/test/e2e/test.d.ts
@@ -1,4 +1,4 @@
-declare module 'unittest/unittest' {
+declare module 'test/test' {
   function test(msg: string, fn: () => void);
   function expect(a: any, b: any);
   function equals(a: any): any;


### PR DESCRIPTION
Issue #331
