### PR TITLE
feat(): Add support for void generic argument, which translates to dynamic

### DIFF
--- a/lib/base.ts
+++ b/lib/base.ts
@@ -75,6 +75,12 @@ export class TranspilerBase {
 
   maybeVisitTypeArguments(n: {typeArguments?: ts.NodeArray<ts.TypeNode>}) {
     if (n.typeArguments) {
+      // If it's a single type argument `<void>`, ignore it and emit nothing.
+      // This is particularly useful for `Promise<void>`, see
+      // https://github.com/dart-lang/sdk/issues/2231#issuecomment-108313639
+      if (n.typeArguments.length == 1 && n.typeArguments[0].kind == ts.SyntaxKind.VoidKeyword) {
+        return;
+      }
       this.emit('<');
       this.visitList(n.typeArguments);
       this.emit('>');

--- a/test/type_test.ts
+++ b/test/type_test.ts
@@ -45,4 +45,9 @@ describe('type arguments', () => {
   it('should support use', () => {
     expectTranslate('class X extends Y<A, B> { }').to.equal('class X extends Y<A, B> {}');
   });
+  it('should remove single <void> generic argument', () => {
+    expectTranslate('var x: X<number>;').to.equal('X<num> x;');
+    expectTranslate('class X extends Y<void> { }').to.equal('class X extends Y {}');
+    expectTranslate('var x = new Promise<void>();').to.equal('var x = new Promise();');
+  });
 });


### PR DESCRIPTION
This allows us to use stuff like:

``` typescript
var x: Promise<void> = new Promise((resolve) => resolve());
```

Which before was harder because we couldn't use `void` as a generic type.
