### PR TITLE
feat(facade): translate the Promise type without explicit re-export

### DIFF
--- a/lib/facade_converter.ts
+++ b/lib/facade_converter.ts
@@ -97,7 +97,8 @@ export class FacadeConverter extends base.TranspilerBase {
       "XMLHttpRequest": "dart:html",
       "KeyboardEvent": "dart:html",
       "Uint8Array": "dart:typed_arrays",
-      "ArrayBuffer": "dart:typed_arrays"
+      "ArrayBuffer": "dart:typed_arrays",
+      "Promise": "dart:async"
     };
     var emitted: Set = {};
     this.emitImports(sourceFile, libraries, emitted, sourceFile);
@@ -227,6 +228,7 @@ export class FacadeConverter extends base.TranspilerBase {
     'XMLHttpRequest': 'HttpRequest',
     'Uint8Array': 'Uint8List',
     'ArrayBuffer': 'ByteBuffer',
+    'Promise': 'Future',
 
     // Dart has two different incompatible DOM APIs
     // https://github.com/angular/angular/issues/2770

--- a/test/facade_converter_test.ts
+++ b/test/facade_converter_test.ts
@@ -36,11 +36,11 @@ function getSources(str: string): {[k: string]: string} {
     'angular2/src/core/di/forward_ref.d.ts': `
         export declare function forwardRef<T>(x: T): T;`,
     'angular2/typings/es6-promise/es6-promise.d.ts': `
-        export declare class Promise<R> {}`,
+        declare class Promise<R> {}
+        declare module Promise {}`,
     'node_modules/rxjs/Observable.d.ts': `
         export declare class Observable {}`,
     'angular2/src/facade/async.ts': `
-        export {Promise} from 'angular2/typings/es6-promise/es6-promise';
         export {Observable} from 'rxjs/Observable';`,
     'angular2/src/facade/collection.ts': `
         export declare var Map;`,
@@ -76,16 +76,14 @@ function expectErroneousWithType(str: string) {
 describe('type based translation', () => {
   describe('Dart type substitution', () => {
     it('finds registered substitutions', () => {
-      expectWithTypes(
-          'import {Promise, Observable} from "angular2/src/facade/async"; var p: Promise<Date>;')
-          .to.equal(`import "package:angular2/src/facade/async.dart" show Future, Stream;
+      expectWithTypes('import {Observable} from "angular2/src/facade/async"; var p: Promise<Date>;')
+          .to.equal(`import "dart:async";
+import "package:angular2/src/facade/async.dart" show Stream;
 
 Future<DateTime> p;`);
-      expectWithTypes(
-          'import {Promise} from "angular2/src/facade/async"; var y = x instanceof Promise;')
-          .to.equal(`import "package:angular2/src/facade/async.dart" show Future;
+      expectWithTypes('var y: Promise;').to.equal(`import "dart:async";
 
-var y = x is Future;`);
+Future y;`);
       expectWithTypes('var n: Node;').to.equal('dynamic n;');
       expectWithTypes('var xhr: XMLHttpRequest;').to.equal(`import "dart:html";
 


### PR DESCRIPTION
Needed for https://github.com/angular/angular/issues/6468
