### PR TITLE
Sanitize TypeScript doc strings to remove tags not recognized by dartdoc

### DIFF
--- a/lib/main.ts
+++ b/lib/main.ts
@@ -275,7 +275,19 @@ export class Transpiler {
   private normalizeSlashes(path: string) { return path.replace(/\\/g, '/'); }
 
   private translateComment(comment: string): string {
-    return comment.replace(/\{@link ([^\}]+)\}/g, '[$1]');
+    comment = comment.replace(/\{@link ([^\}]+)\}/g, '[$1]');
+
+    // Remove the following tags and following comments till end of line.
+    comment = comment.replace(/@param.*$/gm, '');
+    comment = comment.replace(/@throws.*$/gm, '');
+    comment = comment.replace(/@return.*$/gm, '');
+
+    // Remove the following tags.
+    comment = comment.replace(/@module/g, '');
+    comment = comment.replace(/@description/g, '');
+    comment = comment.replace(/@deprecated/g, '');
+
+    return comment;
   }
 }
 

--- a/test/main_test.ts
+++ b/test/main_test.ts
@@ -41,6 +41,56 @@ class A {
       expectTranslate('/** {@link this/place} */ a').to.equal('/** [this/place] */ a;');
       expectTranslate('/* {@link 1} {@link 2} */ a').to.equal('/* [1] [2] */ a;');
     });
+    it('removes @module doc tags', () => {
+      expectTranslate(`/** @module
+  * This is a module for doing X.
+  */`).to.equal(`/** 
+  * This is a module for doing X.
+  */`);
+    });
+    it('removes @description doc tags', () => {
+      expectTranslate(`/** @description
+  * This is a module for doing X.
+  */`).to.equal(`/** 
+  * This is a module for doing X.
+  */`);
+    });
+    it('removes @depracted doc tags', () => {
+      expectTranslate(`/**
+  * Use SomethingElse instead.
+  * @deprecated
+  */`).to.equal(`/**
+  * Use SomethingElse instead.
+  * 
+  */`);
+    });
+    it('removes @param doc tags', () => {
+      expectTranslate(`/**
+  * Method to do blah.
+  * @param doc Document.
+  */`).to.equal(`/**
+  * Method to do blah.
+  * 
+  */`);
+    });
+    it('removes @return doc tags', () => {
+      expectTranslate(`/**
+  * Method to do blah.
+  * @return {String}
+  */`).to.equal(`/**
+  * Method to do blah.
+  * 
+  */`);
+    });
+    it('removes @throws doc tags', () => {
+      expectTranslate(`/**
+  * Method to do blah.
+  * @throws ArgumentException If arguments are wrong
+  */`).to.equal(`/**
+  * Method to do blah.
+  * 
+  */`);
+    });
   });
 
   describe('errors', () => {


### PR DESCRIPTION
Fixes #341 
