### PR TITLE
fix(): allow the caller (or CLI) to specify a root directory for typings

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -89,6 +89,7 @@ gulp.task('test.e2e', ['test.compile'], function(done) {
 
   // run node with a shell so we can wildcard all the .ts files
   var cmd = 'node ../lib/main.js --translateBuiltins --basePath=. --destination=. ' +
+      '--typingsRoot=typings/ ' +
       '*.ts angular2/src/facade/lang.d.ts typings/es6-promise/es6-promise.d.ts';
   // Paths must be relative to our source root, so run with cwd == dir.
   spawn('sh', ['-c', cmd], {stdio: 'inherit', cwd: dir}).on('close', function(code, signal) {

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -40,6 +40,10 @@ export interface TranspilerOptions {
    * Enforce conventions of public/private keyword and underscore prefix
    */
   enforceUnderscoreConventions?: boolean;
+  /**
+   * Sets a root path to look for typings used by the facade converter.
+   */
+  typingsRoot?: string;
 }
 
 export const COMPILER_OPTIONS: ts.CompilerOptions = {
@@ -62,7 +66,8 @@ export class Transpiler {
   private fc: FacadeConverter;
 
   constructor(private options: TranspilerOptions = {}) {
-    this.fc = new FacadeConverter(this);
+    // TODO: Remove the angular2 default when angular uses typingsRoot.
+    this.fc = new FacadeConverter(this, options.typingsRoot || 'angular2/typings/');
     this.transpilers = [
       new CallTranspiler(this, this.fc),  // Has to come before StatementTranspiler!
       new DeclarationTranspiler(this, this.fc, options.enforceUnderscoreConventions),

--- a/test/facade_converter_test.ts
+++ b/test/facade_converter_test.ts
@@ -33,10 +33,10 @@ var es6RuntimeDeclarations = `
 
 function getSources(str: string): {[k: string]: string} {
   var srcs: {[k: string]: string} = {
-    'angular2/typings/es6-shim/es6-shim': es6RuntimeDeclarations,
+    'some/path/to/typings/es6-shim/es6-shim': es6RuntimeDeclarations,
     'angular2/src/core/di/forward_ref.d.ts': `
         export declare function forwardRef<T>(x: T): T;`,
-    'typings/es6-promise/es6-promise.d.ts':
+    'some/path/to/typings/es6-promise/es6-promise.d.ts':
         fs.readFileSync('typings/es6-promise/es6-promise.d.ts', 'utf-8'),
     'node_modules/rxjs/Observable.d.ts': `
         export declare class Observable {}`,
@@ -62,7 +62,8 @@ function getSources(str: string): {[k: string]: string} {
 
 const COMPILE_OPTS = {
   translateBuiltins: true,
-  failFast: true
+  failFast: true,
+  typingsRoot: 'some/path/to/typings/'
 };
 
 function expectWithTypes(str: string) {


### PR DESCRIPTION
This allows the caller to put the typings anywhere and still be able to use us without waiting for a release of ts2dart.
